### PR TITLE
fixes and improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.13 FATAL_ERROR)
 #-----------------------------------------------------------------
 # The project
 #-----------------------------------------------------------------
-project (SolidFrame VERSION 12.1)
+project (SolidFrame VERSION 12.2)
 
 message("SolidFrame version: ${PROJECT_VERSION} - ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}")
 #-----------------------------------------------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,9 +58,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 #-----------------------------------------------------------------
 
 set(EXTERNAL_DIR "" CACHE PATH "External dependencies directory")
+set(FORTIFY "ON" CACHE BOOL "Fortify C++")
 
 message("Install directory: \"${CMAKE_INSTALL_PREFIX}\"")
 message("External directory: \"${EXTERNAL_DIR}\"")
+message("Fortify: \"${FORTIFY}\"")
 
 list(APPEND CMAKE_PREFIX_PATH ${EXTERNAL_PATH})
 
@@ -277,6 +279,37 @@ endif()
 if(NOT ON_FOUND)
     message(FATAL_ERROR "\r\n === Unsupported system - please contact project owner ===\r\n")
 endif(NOT ON_FOUND)
+
+
+if(FORTIFY AND (SOLID_ON_LINUX OR SOLID_ON_FREEBSD OR SOLID_ON_DARWIN))
+    message("Fortifying C++")
+    include(CheckCXXSymbolExists)
+    if(cxx_std_20 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+    set(header version)
+    else()
+    set(header ciso646)
+    endif()
+
+    check_cxx_symbol_exists(_LIBCPP_VERSION ${header} LIBCPP)
+    if(LIBCPP)
+    # Logic for libc++
+    endif()
+
+    check_cxx_symbol_exists(__GLIBCXX__ ${header} GLIBCXX)
+    if(GLIBCXX)
+    # Logic for libstdc++
+
+    add_compile_options(
+        #-fpie -Wl,-pie
+        #-fpic -shared
+        "$<$<CONFIG:MAINTAIN>:SHELL: -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -pipe -fasynchronous-unwind-tables -fexceptions -fstack-clash-protection -fcf-protection -Wl,-z,relro>"
+        "$<$<CONFIG:DEBUG>:SHELL: -Wall -O2 -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -pipe -fasynchronous-unwind-tables -fexceptions -fstack-clash-protection -fcf-protection -Wl,-z,relro>"
+        "$<$<CONFIG:RELEASE>:SHELL: -Wall -D_FORTIFY_SOURCE=2 -D_GLIBCXX_ASSERTIONS -pipe -fasynchronous-unwind-tables -fexceptions -fstack-clash-protection -fcf-protection -Wl,-z,relro>"
+        "$<$<CONFIG:CUSTOM>:>"
+    )
+    
+    endif()
+endif()
 
 #-----------------------------------------------------------------
 # Find external libraries

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,3 +1,6 @@
+## 20250109
+ * improvements and fixes on reflection
+
 ## 20250106
  * use std::variant in example_threadpool
  * TypeToType -> std::type_identity

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,5 +1,6 @@
 ## 20250106
  * use std::variant in example_threadpool
+ * TypeToType -> std::type_identity
 
 ## 20241214
  * mprpc: add support for ConnectionContext::pauseRead and Connection::Context::resumeRead

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,3 +1,5 @@
+## 20241214
+ * mprpc: add support for ConnectionContext::pauseRead and Connection::Context::resumeRead
 
 ## 20241210
  * aio: stream fix not call doTrySend or doTryRecv after disconnect

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,3 +1,6 @@
+## 20250106
+ * use std::variant in example_threadpool
+
 ## 20241214
  * mprpc: add support for ConnectionContext::pauseRead and Connection::Context::resumeRead
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,3 +1,6 @@
+## 20250119
+ * release 12.2
+
 ## 20250109
  * improvements and fixes on reflection
 

--- a/JOURNAL.md
+++ b/JOURNAL.md
@@ -1,4 +1,9 @@
 
+## 20241210
+ * aio: stream fix not call doTrySend or doTryRecv after disconnect
+ * mprpc: do not reset timer on onSend with error if connection already stopping
+ * mprpc: add support for ConnectionContext::stop() for stopping the connection
+
 ## 20241116
  * mprpc::Connection fix too many keep alive messages
 

--- a/RELEASES.md
+++ b/RELEASES.md
@@ -1,5 +1,14 @@
 # SolidFrame Releases
 
+## Version 12.2
+ * improvements and fixes on reflection
+ * use std::variant in example_threadpool
+ * TypeToType -> std::type_identity
+ * mprpc: add support for ConnectionContext::pauseRead and Connection::Context::resumeRead
+ * aio: stream fix not call doTrySend or doTryRecv after disconnect
+ * mprpc: do not reset timer on onSend with error if connection already stopping
+ * mprpc: add support for ConnectionContext::stop() for stopping the connection
+
 ## Version 12.1
 * Coverity fixes
 

--- a/cmake/check.config.cmake
+++ b/cmake/check.config.cmake
@@ -49,5 +49,9 @@ file (READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/check/pthread_spinlock.cpp" source
 
 CHECK_CXX_SOURCE_COMPILES("${source_code}" SOLID_USE_PTHREAD_SPINLOCK)
 
+file (READ "${CMAKE_CURRENT_SOURCE_DIR}/cmake/check/stringstream_view.cpp" source_code)
+
+CHECK_CXX_SOURCE_COMPILES("${source_code}" SOLID_USE_STRINGSTREAM_VIEW)
+
 #TODO:
 #set(SOLID_FRAME_AIO_REACTOR_USE_SPINLOCK TRUE)

--- a/cmake/check/stringstream_view.cpp
+++ b/cmake/check/stringstream_view.cpp
@@ -1,0 +1,11 @@
+#include <iostream>
+#include <sstream>
+using namespace std;
+
+int main()
+{
+    ostringstream oss;
+    oss << "test";
+    cout << oss.view() << endl;
+    return 0;
+}

--- a/configure
+++ b/configure
@@ -101,6 +101,7 @@ INSTALL_PREFIX=
 EXTRA_COMPILE_OPTIONS=
 EXTRA_LINK_OPTIONS=
 ARCHITECTURE=
+FORTIFY="OFF"
 
 #echo "$@"
 pass_arg_count=0
@@ -174,6 +175,9 @@ do
     --test-site)
         shift
         TEST_SITE="$1"
+        ;;
+    --fortify)
+        FORTIFY="ON"
         ;;
     *)
         HELP="yes"
@@ -256,7 +260,7 @@ for param in "$@"; do
 done
 echo
 
-echo -ne "./configure -f $FOLDER_NAME -F \"$FOLDER_PATH\" -b \"$BUILD_TYPE\" -g \"$GENERATOR\" -e \"$EXTERNAL_DIR\" \"$@\" \"$SRC_PATH\"\r\n" > configure.txt
+echo -ne "./configure -f $FOLDER_NAME -F \"$FOLDER_PATH\" -b \"$BUILD_TYPE\" -g \"$GENERATOR\" -e \"$EXTERNAL_DIR\" \"$@\" \"$SRC_PATH\" \"$FORTIFY\" \r\n" > configure.txt
 
 if [ "$GENERATOR" = "" ]; then
     echo "Using cmake's default generator"
@@ -272,7 +276,7 @@ else
     echo "Using architecture $ARCHITECTURE - ${ARC[@]}"
 fi
 
-exec cmake "${GEN[@]}" "${ARC[@]}" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DEXTERNAL_DIR:PATH="$EXTERNAL_DIR" -DEXTRA_COMPILE_OPTIONS:STRING="$EXTRA_COMPILE_OPTIONS" -DEXTRA_LINK_OPTIONS:STRING="$EXTRA_LINK_OPTIONS" -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" "$@" "$SRC_PATH"
+exec cmake "${GEN[@]}" "${ARC[@]}" -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DEXTERNAL_DIR:PATH="$EXTERNAL_DIR" -DEXTRA_COMPILE_OPTIONS:STRING="$EXTRA_COMPILE_OPTIONS" -DEXTRA_LINK_OPTIONS:STRING="$EXTRA_LINK_OPTIONS" -DCMAKE_INSTALL_PREFIX="$INSTALL_PREFIX" -DFORTIFY:BOOL=$FORTIFY "$@" "$SRC_PATH"
 
 echo "Done!"
 

--- a/examples/utility/threadpool/example_threadpool.cpp
+++ b/examples/utility/threadpool/example_threadpool.cpp
@@ -1,6 +1,6 @@
-// example_ThreadPool.cpp
+// example_threadpool.cpp
 //
-// Copyright (c) 2007, 2008, 2018 Valentin Palade (vipalade @ gmail . com)
+// Copyright (c) 2007, 2008, 2018, 2025 Valentin Palade (vipalade @ gmail . com)
 //
 // This file is part of SolidFrame framework.
 //
@@ -9,26 +9,126 @@
 //
 #include "solid/system/log.hpp"
 #include "solid/utility/threadpool.hpp"
+#include <cassert>
 #include <iostream>
-#include <thread>
-
+#include <mutex>
+#include <string>
+#include <variant>
 using namespace std;
 using namespace solid;
 
+namespace {
+Logger logger{"test"};
+} // namespace
+
+struct First {
+    uint64_t v1_;
+
+    First(uint64_t _v)
+        : v1_(_v)
+    {
+    }
+};
+
+struct Second {
+    uint64_t v1_;
+    uint64_t v2_;
+
+    Second(uint64_t _v)
+        : v1_(_v)
+        , v2_(_v)
+    {
+    }
+};
+
+struct Third {
+    uint64_t v1_;
+    uint64_t v2_;
+    uint64_t v3_;
+
+    Third(uint64_t _v)
+        : v1_(_v)
+        , v2_(_v)
+        , v3_(_v)
+    {
+    }
+};
+
+using VariantT = std::variant<string, First, Second, Third, unique_ptr<Third>>;
+
+using ThreadPoolT = ThreadPool<VariantT, size_t>;
+
+struct Context {
+    mutex mtx_;
+};
+
+void handle(First& _rv, Context& _rctx)
+{
+    lock_guard<mutex> lock(_rctx.mtx_);
+    solid_log(logger, Info, "Handle First");
+}
+
+void handle(Second& _rv, Context& _rctx)
+{
+    lock_guard<mutex> lock(_rctx.mtx_);
+    solid_log(logger, Info, "Handle Second");
+}
+
+void handle(Third& _rv, Context& _rctx)
+{
+    lock_guard<mutex> lock(_rctx.mtx_);
+    solid_log(logger, Info, "Handle Third");
+}
+
+void handle(string& _rv, Context& _rctx)
+{
+    lock_guard<mutex> lock(_rctx.mtx_);
+    solid_log(logger, Info, "Handle string " << _rv);
+}
+
+void handle(unique_ptr<Third>& _rv, Context& _rctx)
+{
+    lock_guard<mutex> lock(_rctx.mtx_);
+    solid_log(logger, Info, "Handle unique_ptr<Third>");
+}
+
 int main(int argc, char* argv[])
 {
-    solid::log_start(std::cerr, {".*:VIEW"});
+    solid::log_start(std::cerr, {".*:EW", "test:VIEW"});
 
-    ThreadPool<int, size_t> wp{
-        {1, 100, 0}, [](const size_t) {}, [](const size_t) {},
-        [](int _v) {
-            solid_log(generic_logger, Info, "v = " << _v);
-            std::this_thread::sleep_for(std::chrono::milliseconds(_v * 10));
+    Context ctx;
+
+    ThreadPoolT tp{
+        {4},
+        [](size_t, Context&) {},
+        [](size_t, Context&) {},
+        [](VariantT& _var, Context& _rctx) {
+            std::visit([&_rctx](auto& _rv) { handle(_rv, _rctx); }, _var);
         },
-        [](const size_t) {}};
+        [](size_t, Context&) {
 
-    for (int i(0); i < 100; ++i) {
-        wp.pushOne(i);
+        },
+        ref(ctx)};
+
+    for (size_t i = 0; i < 100; ++i) {
+        switch (i % variant_size_v<VariantT>) {
+        case 0:
+            tp.pushOne(to_string(i));
+            break;
+        case 1:
+            tp.pushOne(First(i));
+            break;
+        case 2:
+            tp.pushOne(Second(i));
+            break;
+        case 3:
+            tp.pushOne(Third(i));
+            break;
+        case 4:
+            tp.pushOne(make_unique<Third>(i));
+            break;
+        default:
+            assert(false);
+        }
     }
-    return 0;
 }

--- a/prerequisites/build
+++ b/prerequisites/build
@@ -24,7 +24,7 @@ printUsage()
     echo
 }
 
-OPENSSL_ADDR="https://www.openssl.org/source/openssl-3.1.2.tar.gz"
+OPENSSL_ADDR="https://github.com/openssl/openssl/releases/download/openssl-3.4.0/openssl-3.4.0.tar.gz"
 
 SYSTEM=
 BIT64=

--- a/solid/frame/aio/aiostream.hpp
+++ b/solid/frame/aio/aiostream.hpp
@@ -103,7 +103,7 @@ class Stream : public CompletionHandler {
 
         void operator()(ThisT& _rthis, ReactorContext& _rctx)
         {
-            if (_rthis.doTryRecv(_rctx)) {
+            if (_rctx.systemError() || _rthis.doTryRecv(_rctx)) {
                 const size_t recv_sz = _rthis.recv_buf_sz;
                 F            tmp{std::forward<F>(f)};
                 _rthis.doClearRecv(_rctx);
@@ -123,7 +123,7 @@ class Stream : public CompletionHandler {
 
         void operator()(ThisT& _rthis, ReactorContext& _rctx)
         {
-            while (_rthis.doTrySend(_rctx)) {
+            while (_rctx.systemError() || _rthis.doTrySend(_rctx)) {
                 if (_rthis.send_buf_sz == _rthis.send_buf_cp) {
                     F tmp{std::forward<F>(f)};
                     _rthis.doClearSend(_rctx);
@@ -410,6 +410,11 @@ public:
             error(_rctx, error_already);
         }
         return true;
+    }
+
+    void cancelRecv(ReactorContext& _rctx)
+    {
+        doClearRecv(_rctx);
     }
 
     template <typename F>

--- a/solid/frame/aio/openssl/src/aiosecuresocket.cpp
+++ b/solid/frame/aio/openssl/src/aiosecuresocket.cpp
@@ -446,8 +446,9 @@ Socket::Socket(
     pssl = SSL_new(_rctx.pctx);
     ::SSL_set_mode(pssl, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
     if (device()) {
-        int rv = SSL_set_fd(pssl, device().descriptor());
+        const int rv = SSL_set_fd(pssl, device().descriptor());
         solid_assert_log(rv != 0, logger);
+        (void)rv;
     }
 }
 

--- a/solid/frame/aio/src/aiolistener.cpp
+++ b/solid/frame/aio/src/aiolistener.cpp
@@ -27,7 +27,7 @@ const LoggerT logger("solid::frame::aio");
     // rthis.completionCallback(on_dummy_completion);
     rthis.completionCallback(&on_completion);
     // rthis.contextBind(_rctx);
-    rthis.s.initAccept(_rctx);
+    rthis.s_.initAccept(_rctx);
 }
 
 /*static*/ void Listener::on_completion(CompletionHandler& _rch, ReactorContext& _rctx)
@@ -36,11 +36,11 @@ const LoggerT logger("solid::frame::aio");
 
     switch (rthis.reactorEvent(_rctx)) {
     case ReactorEventE::Recv:
-        if (!solid_function_empty(rthis.f)) {
+        if (!solid_function_empty(rthis.f_)) {
             SocketDevice sd;
             FunctionT    tmpf;
-            std::swap(tmpf, rthis.f);
-            solid_assert_log(solid_function_empty(rthis.f), logger);
+            std::swap(tmpf, rthis.f_);
+            solid_assert_log(solid_function_empty(rthis.f_), logger);
             rthis.doAccept(_rctx, sd);
 
             tmpf(_rctx, sd);
@@ -48,10 +48,10 @@ const LoggerT logger("solid::frame::aio");
         break;
     case ReactorEventE::Error:
     case ReactorEventE::Hangup:
-        if (!solid_function_empty(rthis.f)) {
+        if (!solid_function_empty(rthis.f_)) {
             SocketDevice sd;
             FunctionT    tmpf;
-            std::swap(tmpf, rthis.f);
+            std::swap(tmpf, rthis.f_);
 
             rthis.error(_rctx, error_listener_hangup);
 
@@ -72,9 +72,9 @@ const LoggerT logger("solid::frame::aio");
     Listener&    rthis = *pthis;
     SocketDevice sd;
 
-    if (!solid_function_empty(rthis.f) && rthis.doTryAccept(_rctx, sd)) {
+    if (!solid_function_empty(rthis.f_) && rthis.doTryAccept(_rctx, sd)) {
         FunctionT tmpf;
-        std::swap(tmpf, rthis.f);
+        std::swap(tmpf, rthis.f_);
         tmpf(_rctx, sd);
     }
 }
@@ -85,14 +85,14 @@ const LoggerT logger("solid::frame::aio");
 
 SocketDevice Listener::reset(ReactorContext& _rctx, SocketDevice&& _rnewdev)
 {
-    if (s.device()) {
-        remDevice(_rctx, s.device());
+    if (s_.device()) {
+        remDevice(_rctx, s_.device());
     }
 
     contextBind(_rctx);
 
-    SocketDevice tmpsd = s.resetAccept(_rctx, std::move(_rnewdev));
-    if (s.device()) {
+    SocketDevice tmpsd = s_.resetAccept(_rctx, std::move(_rnewdev));
+    if (s_.device()) {
         completionCallback(&on_completion);
     }
     return tmpsd;
@@ -106,7 +106,7 @@ void Listener::doPostAccept(ReactorContext& _rctx)
 bool Listener::doTryAccept(ReactorContext& _rctx, SocketDevice& _rsd)
 {
     bool       can_retry;
-    ErrorCodeT err = s.accept(_rctx, _rsd, can_retry);
+    ErrorCodeT err = s_.accept(_rctx, _rsd, can_retry);
 
     if (!err) {
     } else if (can_retry) {
@@ -121,7 +121,7 @@ bool Listener::doTryAccept(ReactorContext& _rctx, SocketDevice& _rsd)
 void Listener::doAccept(ReactorContext& _rctx, SocketDevice& _rsd)
 {
     bool       can_retry;
-    ErrorCodeT err = s.accept(_rctx, _rsd, can_retry);
+    ErrorCodeT err = s_.accept(_rctx, _rsd, can_retry);
 
     if (!err) {
     } else if (can_retry) {
@@ -134,9 +134,9 @@ void Listener::doAccept(ReactorContext& _rctx, SocketDevice& _rsd)
 
 void Listener::doClear(ReactorContext& _rctx)
 {
-    solid_function_clear(f);
-    remDevice(_rctx, s.device());
-    f = &on_dummy;
+    solid_function_clear(f_);
+    remDevice(_rctx, s_.device());
+    f_ = &on_dummy;
 }
 
 } // namespace aio

--- a/solid/frame/aio/test/test_echo_tcp_stress.cpp
+++ b/solid/frame/aio/test/test_echo_tcp_stress.cpp
@@ -193,6 +193,7 @@ private:
     {
         SecureConnection& rthis = static_cast<SecureConnection&>(_rctx.actor());
         solid_dbg(generic_logger, Info, &rthis << " " << _preverified);
+        (void)rthis;
         return _preverified;
     }
 
@@ -365,6 +366,7 @@ private:
     {
         SecureConnection& rthis = static_cast<SecureConnection&>(_rctx.actor());
         solid_dbg(generic_logger, Info, &rthis << " " << _preverified);
+        (void)rthis;
         return _preverified;
     }
 

--- a/solid/frame/mprpc/mprpcmessage.hpp
+++ b/solid/frame/mprpc/mprpcmessage.hpp
@@ -125,13 +125,13 @@ struct MessageHeader {
     SOLID_REFLECT_V1(_rr, _rthis, _rctx)
     {
         if constexpr (std::decay_t<decltype(_rr)>::is_const_reflector) {
-            const MessageFlagsValueT tmp = _rctx.message_flags.toUnderlyingType();
+            const MessageFlagsValueT tmp = _rctx.message_flags_.toUnderlyingType();
             _rr.add(tmp, _rctx, 1, "flags");
-            _rr.add(_rctx.request_id.index, _rctx, 2, "sender_request_index");
-            _rr.add(_rctx.request_id.unique, _rctx, 3, "sender_request_unique");
+            _rr.add(_rctx.request_id_.index, _rctx, 2, "sender_request_index");
+            _rr.add(_rctx.request_id_.unique, _rctx, 3, "sender_request_unique");
             _rr.add(_rthis.sender_request_id_.index, _rctx, 4, "recipient_request_index");
             _rr.add(_rthis.sender_request_id_.unique, _rctx, 5, "recipient_request_unique");
-            if (_rctx.message_flags.has(MessageFlagsE::Relayed)) {
+            if (_rctx.message_flags_.has(MessageFlagsE::Relayed)) {
                 _rr.add(_rthis.relay_, _rctx, 6, "relay");
             }
         } else {

--- a/solid/frame/mprpc/mprpcprotocol.hpp
+++ b/solid/frame/mprpc/mprpcprotocol.hpp
@@ -21,7 +21,7 @@ namespace solid {
 namespace frame {
 namespace mprpc {
 
-struct ConnectionContext;
+class ConnectionContext;
 
 template <class Req>
 struct message_complete_traits;

--- a/solid/frame/mprpc/mprpcsocketstub.hpp
+++ b/solid/frame/mprpc/mprpcsocketstub.hpp
@@ -80,6 +80,8 @@ public:
         frame::aio::ReactorContext& _rctx)
         = 0;
 
+    virtual void cancelRecv(frame::aio::ReactorContext& _rctx) = 0;
+
     virtual bool secureAccept(
         frame::aio::ReactorContext& _rctx, ConnectionContext& _rconctx, OnSecureAcceptF _pf, ErrorConditionT& _rerror);
     virtual bool secureConnect(

--- a/solid/frame/mprpc/mprpcsocketstub_openssl.hpp
+++ b/solid/frame/mprpc/mprpcsocketstub_openssl.hpp
@@ -233,6 +233,11 @@ private:
         return sock;
     }
 
+    void cancelRecv(frame::aio::ReactorContext& _rctx) override
+    {
+        sock.cancelRecv(_rctx);
+    }
+
 private:
     StreamSocketT sock;
 };

--- a/solid/frame/mprpc/mprpcsocketstub_plain.hpp
+++ b/solid/frame/mprpc/mprpcsocketstub_plain.hpp
@@ -53,8 +53,8 @@ private:
         frame::aio::ReactorContext& _rctx, OnSendAllRawF _pf, const char* _pbuf, size_t _bufcp, EventBase& _revent) override final
     {
         struct Closure {
-            OnSendAllRawF pf;
-            EventT        event;
+            const OnSendAllRawF pf;
+            EventT              event;
 
             Closure(OnSendAllRawF _pf, EventBase const& _revent)
                 : pf(_pf)
@@ -84,8 +84,8 @@ private:
         frame::aio::ReactorContext& _rctx, OnRecvSomeRawF _pf, char* _pbuf, size_t _bufcp, EventBase& _revent) override final
     {
         struct Closure {
-            OnRecvSomeRawF pf;
-            EventT         event;
+            const OnRecvSomeRawF pf;
+            EventT               event;
 
             Closure(OnRecvSomeRawF _pf, EventBase const& _revent)
                 : pf(_pf)
@@ -136,6 +136,11 @@ private:
     void prepareSocket(
         frame::aio::ReactorContext& _rctx) override final
     {
+    }
+
+    void cancelRecv(frame::aio::ReactorContext& _rctx) override
+    {
+        sock.cancelRecv(_rctx);
     }
 
 private:

--- a/solid/frame/mprpc/src/mprpcconfiguration.cpp
+++ b/solid/frame/mprpc/src/mprpcconfiguration.cpp
@@ -218,8 +218,8 @@ bool RelayEngine::notifyConnection(Manager& _rm, const ActorIdT& _rrelay_uid, co
 //-----------------------------------------------------------------------------
 void Configuration::init()
 {
-    connection_recv_buffer_start_capacity_kb = static_cast<uint8_t>(memory_page_size() / 1024);
-    connection_send_buffer_start_capacity_kb = static_cast<uint8_t>(memory_page_size() / 1024);
+    connection_recv_buffer_start_capacity_kb = 16;
+    connection_send_buffer_start_capacity_kb = 16;
 
     connection_recv_buffer_max_capacity_kb = connection_send_buffer_max_capacity_kb = 64;
 

--- a/solid/frame/mprpc/src/mprpcconnection.hpp
+++ b/solid/frame/mprpc/src/mprpcconnection.hpp
@@ -191,6 +191,7 @@ protected:
         Raw,
         InPoolWaitQueue,
         Connected, // once set - the flag should not be reset. Is used by pool for restarting
+        PauseRecv,
         LastFlag,
     };
 
@@ -254,6 +255,11 @@ protected:
 
     template <class Ctx>
     bool connect(frame::aio::ReactorContext& _rctx, const SocketAddressInet& _raddr);
+
+    template <class Ctx>
+    void doPauseRead(frame::aio::ReactorContext& _rctx);
+    template <class Ctx>
+    void doResumeRead(frame::aio::ReactorContext& _rctx);
 
 private:
     bool postSendAll(frame::aio::ReactorContext& _rctx, const char* _pbuf, size_t _bufcp, EventBase& _revent);
@@ -334,8 +340,13 @@ private:
     template <class Ctx>
     void doCompleteCancelRequest(frame::aio::ReactorContext& _rctx, const RequestId& _reqid);
 
+    virtual void stop(frame::aio::ReactorContext& _rctx, const ErrorConditionT& _rerr) = 0;
+    virtual void pauseRead(frame::aio::ReactorContext& _rctx)                          = 0;
+    virtual void resumeRead(frame::aio::ReactorContext& _rctx)                         = 0;
+
 private:
-    using TimerT            = frame::aio::SteadyTimer;
+    using TimerT
+        = frame::aio::SteadyTimer;
     using FlagsT            = solid::Flags<FlagsE>;
     using RequestIdVectorT  = MessageWriter::RequestIdVectorT;
     using RecvBufferVectorT = std::vector<SharedBuffer>;
@@ -398,6 +409,10 @@ private:
     void onEvent(frame::aio::ReactorContext& _rctx, EventBase&& _uevent) override;
 
     void doHandleEventResolve(frame::aio::ReactorContext& _rctx, EventBase& _revent);
+
+    void stop(frame::aio::ReactorContext& _rctx, const ErrorConditionT& _rerr) override;
+    void pauseRead(frame::aio::ReactorContext& _rctx) override;
+    void resumeRead(frame::aio::ReactorContext& _rctx) override;
 };
 
 //-----------------------------------------------------------------------------
@@ -417,6 +432,10 @@ public:
 
 private:
     void onEvent(frame::aio::ReactorContext& _rctx, EventBase&& _uevent) override;
+
+    void stop(frame::aio::ReactorContext& _rctx, const ErrorConditionT& _rerr) override;
+    void pauseRead(frame::aio::ReactorContext& _rctx) override;
+    void resumeRead(frame::aio::ReactorContext& _rctx) override;
 };
 
 //-----------------------------------------------------------------------------
@@ -481,6 +500,10 @@ private:
 
     void doHandleEventRelayNew(frame::aio::ReactorContext& _rctx, EventBase& _revent);
     void doHandleEventRelayDone(frame::aio::ReactorContext& _rctx, EventBase& _revent);
+
+    void stop(frame::aio::ReactorContext& _rctx, const ErrorConditionT& _rerr) override;
+    void pauseRead(frame::aio::ReactorContext& _rctx) override;
+    void resumeRead(frame::aio::ReactorContext& _rctx) override;
 };
 
 //-----------------------------------------------------------------------------

--- a/solid/frame/mprpc/src/mprpclistener.hpp
+++ b/solid/frame/mprpc/src/mprpclistener.hpp
@@ -49,8 +49,8 @@ private:
     typedef frame::aio::Listener    ListenerSocketT;
     typedef frame::aio::SteadyTimer TimerT;
 
-    ListenerSocketT sock;
-    TimerT          timer;
+    ListenerSocketT sock_;
+    TimerT          timer_;
 };
 
 } // namespace mprpc

--- a/solid/frame/mprpc/src/mprpcmessagereader.cpp
+++ b/solid/frame/mprpc/src/mprpcmessagereader.cpp
@@ -49,7 +49,7 @@ size_t MessageReader::read(
     while (pbufpos != pbufend) {
         if (state_ == StateE::ReadPacketHead) {
             // try read the header
-            if ((pbufend - pbufpos) >= PacketHeader::size_of_header) {
+            if ((pbufend - pbufpos) >= static_cast<ptrdiff_t>(PacketHeader::size_of_header)) {
                 state_ = StateE::ReadPacketBody;
             } else {
                 break;

--- a/solid/frame/mprpc/src/mprpcmessagereader.cpp
+++ b/solid/frame/mprpc/src/mprpcmessagereader.cpp
@@ -216,7 +216,7 @@ bool MessageReader::doConsumeMessageHeader(
         _pbufpos = _receiver.protocol().loadValue(_pbufpos, _message_size);
         solid_log(logger, Verbose, "msgidx = " << _msgidx << " message_size = " << _message_size);
         if (_message_size <= static_cast<size_t>(_pbufend - _pbufpos)) {
-            _receiver.context().pmessage_header = &rmsgstub.message_header_;
+            _receiver.context().pmessage_header_ = &rmsgstub.message_header_;
 
             const ptrdiff_t rv = rmsgstub.state_ == MessageStub::StateE::ReadHeadStart ? rmsgstub.deserializer_ptr_->run(_receiver.context(), _pbufpos, _message_size, rmsgstub.message_header_) : rmsgstub.deserializer_ptr_->run(_receiver.context(), _pbufpos, _message_size);
 
@@ -290,7 +290,7 @@ bool MessageReader::doConsumeMessageBody(
 
             if (_message_size <= static_cast<size_t>(_pbufend - _pbufpos)) {
 
-                _receiver.context().pmessage_header = &rmsgstub.message_header_;
+                _receiver.context().pmessage_header_ = &rmsgstub.message_header_;
 
                 const ptrdiff_t rv = rmsgstub.state_ == MessageStub::StateE::ReadBodyStart ? rmsgstub.deserializer_ptr_->run(_receiver.context(), _pbufpos, _message_size, rmsgstub.message_ptr_) : rmsgstub.deserializer_ptr_->run(_receiver.context(), _pbufpos, _message_size);
 

--- a/solid/frame/mprpc/src/mprpcmessagewriter.cpp
+++ b/solid/frame/mprpc/src/mprpcmessagewriter.cpp
@@ -672,16 +672,16 @@ char* MessageWriter::doWriteMessageHead(
     MessageStub& rmsgstub             = message_vec_[_msgidx];
     rmsgstub.msgbundle_.message_flags = Message::update_state_flags(Message::clear_state_flags(rmsgstub.msgbundle_.message_flags) | Message::state_flags(rmsgstub.msgbundle_.message_ptr->flags()));
 
-    _rsender.context().request_id.index  = static_cast<uint32_t>(_msgidx + 1);
-    _rsender.context().request_id.unique = rmsgstub.unique_;
-    _rsender.context().message_flags     = rmsgstub.msgbundle_.message_flags;
+    _rsender.context().request_id_.index  = static_cast<uint32_t>(_msgidx + 1);
+    _rsender.context().request_id_.unique = rmsgstub.unique_;
+    _rsender.context().message_flags_     = rmsgstub.msgbundle_.message_flags;
     if (rmsgstub.msgbundle_.message_relay_header_.has_value()) {
         // solid_assert_log(_rsender.context().message_flags.isSet(MessageFlagsE::Relayed), logger, ""<<rmsgstub.msgbundle_.message_ptr.get());
-        _rsender.context().message_flags.set(MessageFlagsE::Relayed);
+        _rsender.context().message_flags_.set(MessageFlagsE::Relayed);
         _rsender.context().pmessage_relay_header_ = &rmsgstub.msgbundle_.message_relay_header_.value();
     } else {
         // solid_assert_log(!_rsender.context().message_flags.isSet(MessageFlagsE::Relayed), logger, ""<<rmsgstub.msgbundle_.message_ptr.get());
-        _rsender.context().message_flags.reset(MessageFlagsE::Relayed);
+        _rsender.context().message_flags_.reset(MessageFlagsE::Relayed);
         _rsender.context().pmessage_relay_header_ = nullptr;
     }
 
@@ -726,14 +726,14 @@ char* MessageWriter::doWriteMessageBody(
 
     MessageStub& rmsgstub = message_vec_[_msgidx];
 
-    _rsender.context().request_id.index  = static_cast<uint32_t>(_msgidx + 1);
-    _rsender.context().request_id.unique = rmsgstub.unique_;
-    _rsender.context().message_flags     = rmsgstub.msgbundle_.message_flags;
+    _rsender.context().request_id_.index  = static_cast<uint32_t>(_msgidx + 1);
+    _rsender.context().request_id_.unique = rmsgstub.unique_;
+    _rsender.context().message_flags_     = rmsgstub.msgbundle_.message_flags;
     if (rmsgstub.msgbundle_.message_relay_header_.has_value()) {
-        _rsender.context().message_flags.set(MessageFlagsE::Relayed);
+        _rsender.context().message_flags_.set(MessageFlagsE::Relayed);
         _rsender.context().pmessage_relay_header_ = &rmsgstub.msgbundle_.message_relay_header_.value();
     } else {
-        _rsender.context().message_flags.reset(MessageFlagsE::Relayed);
+        _rsender.context().message_flags_.reset(MessageFlagsE::Relayed);
         _rsender.context().pmessage_relay_header_ = nullptr;
     }
 
@@ -788,10 +788,10 @@ char* MessageWriter::doWriteRelayedHead(
 
     MessageStub& rmsgstub = message_vec_[_msgidx];
 
-    _rsender.context().request_id.index  = static_cast<uint32_t>(_msgidx + 1);
-    _rsender.context().request_id.unique = rmsgstub.unique_;
-    _rsender.context().message_flags     = rmsgstub.prelay_data_->pmessage_header_->flags_;
-    _rsender.context().message_flags.set(MessageFlagsE::Relayed);
+    _rsender.context().request_id_.index  = static_cast<uint32_t>(_msgidx + 1);
+    _rsender.context().request_id_.unique = rmsgstub.unique_;
+    _rsender.context().message_flags_     = rmsgstub.prelay_data_->pmessage_header_->flags_;
+    _rsender.context().message_flags_.set(MessageFlagsE::Relayed);
     _rsender.context().pmessage_relay_header_ = &rmsgstub.prelay_data_->pmessage_header_->relay_;
 
     const ptrdiff_t rv = rmsgstub.state_ == MessageStub::StateE::RelayedHeadStart ? rmsgstub.serializer_ptr_->run(_rsender.context(), _pbufpos, _pbufend - _pbufpos, *rmsgstub.prelay_data_->pmessage_header_) : rmsgstub.serializer_ptr_->run(_rsender.context(), _pbufpos, _pbufend - _pbufpos);
@@ -982,7 +982,7 @@ void MessageWriter::doTryCompleteMessageAfterSerialization(
     MessageStub& rmsgstub(message_vec_[_msgidx]);
     RequestId    requid(static_cast<uint32_t>(_msgidx), rmsgstub.unique_);
 
-    solid_log(logger, Info, this << " done serializing message " << requid << ". Message id sent to client " << _rsender.context().request_id);
+    solid_log(logger, Info, this << " done serializing message " << requid << ". Message id sent to client " << _rsender.context().request_id_);
 
     cache(rmsgstub.serializer_ptr_);
 

--- a/solid/frame/mprpc/src/mprpcservice.cpp
+++ b/solid/frame/mprpc/src/mprpcservice.cpp
@@ -2604,8 +2604,6 @@ void Service::acceptIncomingConnection(SocketDevice& _rsd)
 {
     solid_log(logger, Verbose, this);
 
-    configuration().server.socket_device_setup_fnc(_rsd);
-
     size_t pool_index;
     {
         lock_guard<std::mutex> lock(pimpl_->rmutex_);
@@ -2617,6 +2615,8 @@ void Service::acceptIncomingConnection(SocketDevice& _rsd)
             return;
         }
     }
+
+    configuration().server.socket_device_setup_fnc(_rsd);
 
     {
         lock_guard<std::mutex> pool_lock(pimpl_->poolMutex(pool_index));

--- a/solid/frame/mprpc/test/CMakeLists.txt
+++ b/solid/frame/mprpc/test/CMakeLists.txt
@@ -70,6 +70,7 @@ if(OPENSSL_FOUND)
         test_clientserver_download.cpp
         test_clientserver_timeout_secure.cpp
         test_clientserver_topic.cpp
+        test_clientserver_stop.cpp
     )
 
     if(SOLID_ON_WINDOWS)

--- a/solid/frame/mprpc/test/CMakeLists.txt
+++ b/solid/frame/mprpc/test/CMakeLists.txt
@@ -71,6 +71,7 @@ if(OPENSSL_FOUND)
         test_clientserver_timeout_secure.cpp
         test_clientserver_topic.cpp
         test_clientserver_stop.cpp
+        test_clientserver_pause_read.cpp
     )
 
     if(SOLID_ON_WINDOWS)

--- a/solid/frame/mprpc/test/CMakeLists.txt
+++ b/solid/frame/mprpc/test/CMakeLists.txt
@@ -153,6 +153,8 @@ if(OPENSSL_FOUND)
     add_test(NAME TestClientServerTimeoutSecureS        COMMAND  test_mprpc_clientserver test_clientserver_timeout_secure 10 s)
     add_test(NAME TestClientServerTimeoutSecureP        COMMAND  test_mprpc_clientserver test_clientserver_timeout_secure 10 p)
     add_test(NAME TestClientServerTimeoutSecureA        COMMAND  test_mprpc_clientserver test_clientserver_timeout_secure 10 a)
+    add_test(NAME TestClientServerStop                  COMMAND  test_mprpc_clientserver test_clientserver_stop)
+    add_test(NAME TestClientServerPauseRead             COMMAND  test_mprpc_clientserver test_clientserver_pause_read)
 
     set_tests_properties(
         TestClientServerBasic_1        
@@ -197,7 +199,9 @@ if(OPENSSL_FOUND)
         TestClientServerDownload       
         TestClientServerTimeoutSecureS 
         TestClientServerTimeoutSecureP 
-        TestClientServerTimeoutSecureA    
+        TestClientServerTimeoutSecureA
+        TestClientServerStop
+        TestClientServerPauseRead
         PROPERTIES LABELS "mprpc clientserver"
     )
     #==============================================================================

--- a/solid/frame/mprpc/test/multiprotocol_basic/alpha/alphamessages.hpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/alpha/alphamessages.hpp
@@ -62,9 +62,9 @@ struct ThirdMessage : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg({0, 1}, "FirstMessage", solid::TypeToType<FirstMessage>());
-    _rreg({0, 2}, "SecondMessage", solid::TypeToType<SecondMessage>());
-    _rreg({0, 3}, "ThirdMessage", solid::TypeToType<ThirdMessage>());
+    _rreg({0, 1}, "FirstMessage", std::type_identity<FirstMessage>());
+    _rreg({0, 2}, "SecondMessage", std::type_identity<SecondMessage>());
+    _rreg({0, 3}, "ThirdMessage", std::type_identity<ThirdMessage>());
 }
 
 } // namespace alpha_protocol

--- a/solid/frame/mprpc/test/multiprotocol_basic/alpha/client/alphaclient.cpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/alpha/client/alphaclient.cpp
@@ -117,9 +117,8 @@ ErrorConditionT start(
         auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, TypeIdT>(
             reflection::v1::metadata::factory,
             [](auto& _rmap) {
-                auto lambda = [&](const TypeIdT _id, const std::string_view _name, auto const& _rtype) {
-                    using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                    _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+                auto lambda = [&]<typename T>(const TypeIdT _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                    _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
                 };
                 alpha_protocol::configure_protocol(lambda);
             });

--- a/solid/frame/mprpc/test/multiprotocol_basic/alpha/server/alphaserver.hpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/alpha/server/alphaserver.hpp
@@ -15,9 +15,8 @@ void complete_message(
 template <class Reg>
 void register_messages(Reg& _rmap)
 {
-    auto lambda = [&](const TypeIdT _id, const std::string_view _name, auto const& _rtype) {
-        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-        _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+    auto lambda = [&]<typename T>(const TypeIdT _id, const std::string_view _name, std::type_identity<T> const& _rtype) {
+        _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
     };
     alpha_protocol::configure_protocol(lambda);
 }

--- a/solid/frame/mprpc/test/multiprotocol_basic/beta/betamessages.hpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/beta/betamessages.hpp
@@ -75,9 +75,9 @@ struct SecondMessage : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg({1, 1}, "FirstMessage", solid::TypeToType<FirstMessage>());
-    _rreg({1, 2}, "SecondMessage", solid::TypeToType<SecondMessage>());
-    _rreg({1, 3}, "ThirdMessage", solid::TypeToType<ThirdMessage>());
+    _rreg({1, 1}, "FirstMessage", std::type_identity<FirstMessage>());
+    _rreg({1, 2}, "SecondMessage", std::type_identity<SecondMessage>());
+    _rreg({1, 3}, "ThirdMessage", std::type_identity<ThirdMessage>());
 }
 
 } // namespace beta_protocol

--- a/solid/frame/mprpc/test/multiprotocol_basic/beta/client/betaclient.cpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/beta/client/betaclient.cpp
@@ -105,8 +105,8 @@ ErrorConditionT start(
         auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, TypeIdT>(
             reflection::v1::metadata::factory,
             [](auto& _rmap) {
-                auto lambda = [&](const TypeIdT _id, const std::string_view _name, auto const& _rtype) {
-                    using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
+                auto lambda = [&]<typename T>(const TypeIdT _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                    using TypeT = T;
                     if constexpr (std::is_same_v<TypeT, beta_protocol::FirstMessage>) {
                         _rmap.template registerMessage<TypeT>(_id, _name, complete_message_first);
                     } else if constexpr (std::is_same_v<TypeT, beta_protocol::SecondMessage>) {

--- a/solid/frame/mprpc/test/multiprotocol_basic/beta/server/betaserver.hpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/beta/server/betaserver.hpp
@@ -15,9 +15,8 @@ void complete_message(
 template <class Reg>
 void register_messages(Reg& _rmap)
 {
-    auto lambda = [&](const TypeIdT _id, const std::string_view _name, auto const& _rtype) {
-        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-        _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+    auto lambda = [&]<typename T>(const TypeIdT _id, const std::string_view _name, std::type_identity<T> const& _rtype) {
+        _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
     };
     beta_protocol::configure_protocol(lambda);
 }

--- a/solid/frame/mprpc/test/multiprotocol_basic/gamma/client/gammaclient.cpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/gamma/client/gammaclient.cpp
@@ -66,9 +66,8 @@ ErrorConditionT start(
         auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, TypeIdT>(
             reflection::v1::metadata::factory,
             [](auto& _rmap) {
-                auto lambda = [&](const TypeIdT _id, const std::string_view _name, auto const& _rtype) {
-                    using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                    _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+                auto lambda = [&]<typename T>(const TypeIdT _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                    _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
                 };
                 gamma_protocol::configure_protocol(lambda);
             });

--- a/solid/frame/mprpc/test/multiprotocol_basic/gamma/gammamessages.hpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/gamma/gammamessages.hpp
@@ -61,8 +61,8 @@ struct ThirdMessage : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg({2, 1}, "FirstMessage", solid::TypeToType<FirstMessage>());
-    _rreg({2, 2}, "SecondMessage", solid::TypeToType<SecondMessage>());
-    _rreg({2, 3}, "ThirdMessage", solid::TypeToType<ThirdMessage>());
+    _rreg({2, 1}, "FirstMessage", std::type_identity<FirstMessage>());
+    _rreg({2, 2}, "SecondMessage", std::type_identity<SecondMessage>());
+    _rreg({2, 3}, "ThirdMessage", std::type_identity<ThirdMessage>());
 }
 } // namespace gamma_protocol

--- a/solid/frame/mprpc/test/multiprotocol_basic/gamma/server/gammaserver.hpp
+++ b/solid/frame/mprpc/test/multiprotocol_basic/gamma/server/gammaserver.hpp
@@ -31,9 +31,8 @@ void complete_message(
 template <class Reg>
 void register_messages(Reg& _rmap)
 {
-    auto lambda = [&](const TypeIdT _id, const std::string_view _name, auto const& _rtype) {
-        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-        _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+    auto lambda = [&]<typename T>(const TypeIdT _id, const std::string_view _name, std::type_identity<T> const& _rtype) {
+        _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
     };
     gamma_protocol::configure_protocol(lambda);
 }

--- a/solid/frame/mprpc/test/test_clientfrontback_download.cpp
+++ b/solid/frame/mprpc/test/test_clientfrontback_download.cpp
@@ -334,8 +334,9 @@ int test_clientfrontback_download(int argc, char* argv[])
         increment_size = make_number(argv[3]);
     }
 
-    system("rm -rf client_storage");
-    system("rm -rf server_storage");
+    auto rv = system("rm -rf client_storage");
+    rv      = system("rm -rf server_storage");
+    (void)rv;
 
     Directory::create("client_storage");
     Directory::create("server_storage");

--- a/solid/frame/mprpc/test/test_clientfrontback_upload.cpp
+++ b/solid/frame/mprpc/test/test_clientfrontback_upload.cpp
@@ -326,8 +326,9 @@ int test_clientfrontback_upload(int argc, char* argv[])
         increment_size = make_number(argv[3]);
     }
 
-    system("rm -rf client_storage");
-    system("rm -rf server_storage");
+    auto rv = system("rm -rf client_storage");
+    rv      = system("rm -rf server_storage");
+    (void)rv;
 
     Directory::create("client_storage");
     Directory::create("server_storage");

--- a/solid/frame/mprpc/test/test_clientserver_download.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_download.cpp
@@ -216,8 +216,9 @@ int test_clientserver_download(int argc, char* argv[])
         increment_size = make_number(argv[3]);
     }
 
-    system("rm -rf client_storage");
-    system("rm -rf server_storage");
+    auto rv = system("rm -rf client_storage");
+    rv      = system("rm -rf server_storage");
+    (void)rv;
 
     Directory::create("client_storage");
     Directory::create("server_storage");

--- a/solid/frame/mprpc/test/test_clientserver_pause_read.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_pause_read.cpp
@@ -421,8 +421,6 @@ int test_clientserver_pause_read(int argc, char* argv[])
 
         pmprpcclient = &mprpcclient;
 
-        const size_t start_count = 10;
-
         while (true) {
             auto       msg_ptr = frame::mprpc::make_message<Message>(crtwriteidx);
             const auto err     = mprpcclient.sendMessage(

--- a/solid/frame/mprpc/test/test_clientserver_pause_read.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_pause_read.cpp
@@ -1,0 +1,482 @@
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+#include "solid/frame/mprpc/mprpcsocketstub_openssl.hpp"
+
+#include "solid/frame/mprpc/mprpccompression_snappy.hpp"
+#include "solid/frame/mprpc/mprpcconfiguration.hpp"
+#include "solid/frame/mprpc/mprpcprotocol_serialization_v3.hpp"
+#include "solid/frame/mprpc/mprpcservice.hpp"
+
+#include "solid/frame/manager.hpp"
+#include "solid/frame/scheduler.hpp"
+#include "solid/frame/service.hpp"
+
+#include "solid/frame/aio/aioactor.hpp"
+#include "solid/frame/aio/aiolistener.hpp"
+#include "solid/frame/aio/aioreactor.hpp"
+#include "solid/frame/aio/aioresolver.hpp"
+#include "solid/frame/aio/aiotimer.hpp"
+
+#include "solid/utility/threadpool.hpp"
+
+#include "solid/system/exception.hpp"
+
+#include "solid/system/log.hpp"
+
+using namespace std;
+using namespace solid;
+
+using AioSchedulerT  = frame::Scheduler<frame::aio::Reactor<frame::mprpc::EventT>>;
+using SecureContextT = frame::aio::openssl::Context;
+
+namespace {
+
+struct InitStub {
+    size_t                      size;
+    frame::mprpc::MessageFlagsT flags;
+};
+
+using CallPoolT = ThreadPool<Function<void()>, Function<void()>>;
+
+InitStub initarray[] = {
+    {100000, 0},
+    {2000, 0},
+    {4000, 0},
+    {8000, 0},
+    {16000, 0},
+    {32000, 0},
+    {64000, 0},
+    {128000, 0},
+    {256000, 0},
+    {512000, 0},
+    {1024000, 0},
+    {2048000, 0},
+    {4096000, 0},
+    {8192000, 0},
+    {16384000, 0}};
+
+std::string  pattern;
+const size_t initarraysize = sizeof(initarray) / sizeof(InitStub);
+
+std::atomic<size_t> crtwriteidx(0);
+std::atomic<size_t> crtreadidx(0);
+std::atomic<size_t> crtbackidx(0);
+std::atomic<size_t> crtackidx(0);
+
+size_t                    connection_count(0);
+bool                      running = true;
+mutex                     mtx;
+condition_variable        cnd;
+frame::mprpc::Service*    pmprpcclient = nullptr;
+std::atomic<uint64_t>     transfered_size(0);
+std::atomic<size_t>       transfered_count(0);
+bool                      use_context_on_response = false;
+frame::mprpc::RecipientId server_connection_id;
+bool                      server_connection_paused = false;
+
+size_t
+real_size(size_t _sz)
+{
+    // offset + (align - (offset mod align)) mod align
+    return _sz + ((sizeof(uint64_t) - (_sz % sizeof(uint64_t))) % sizeof(uint64_t));
+}
+
+struct Message : frame::mprpc::Message {
+    uint32_t     idx;
+    std::string  str;
+    mutable bool serialized;
+
+    Message(uint32_t _idx)
+        : idx(_idx)
+        , serialized(false)
+    {
+        solid_dbg(generic_logger, Info, "CREATE ---------------- " << this << " idx = " << idx);
+        init();
+    }
+    Message()
+        : serialized(false)
+    {
+        solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
+    }
+    ~Message() override
+    {
+        solid_dbg(generic_logger, Info, "DELETE ---------------- " << this);
+
+        solid_assert(serialized || this->isBackOnSender());
+    }
+
+    SOLID_REFLECT_V1(_rr, _rthis, _rctx)
+    {
+        using ReflectorT = decay_t<decltype(_rr)>;
+
+        _rr.add(_rthis.idx, _rctx, 0, "idx").add(_rthis.str, _rctx, 1, "str");
+
+        if constexpr (ReflectorT::is_const_reflector) {
+            _rthis.serialized = true;
+        }
+    }
+
+    void init()
+    {
+        const size_t sz = real_size(initarray[idx % initarraysize].size);
+        str.resize(sz);
+        const size_t    count        = sz / sizeof(uint64_t);
+        uint64_t*       pu           = reinterpret_cast<uint64_t*>(const_cast<char*>(str.data()));
+        const uint64_t* pup          = reinterpret_cast<const uint64_t*>(pattern.data());
+        const size_t    pattern_size = pattern.size() / sizeof(uint64_t);
+        for (uint64_t i = 0; i < count; ++i) {
+            pu[i] = pup[(idx + i) % pattern_size]; // pattern[i % pattern.size()];
+        }
+    }
+
+    bool check() const
+    {
+        const size_t sz = real_size(initarray[idx % initarraysize].size);
+        solid_dbg(generic_logger, Info, "str.size = " << str.size() << " should be equal to " << sz);
+        if (sz != str.size()) {
+            return false;
+        }
+        // return true;
+        const size_t    count        = sz / sizeof(uint64_t);
+        const uint64_t* pu           = reinterpret_cast<const uint64_t*>(str.data());
+        const uint64_t* pup          = reinterpret_cast<const uint64_t*>(pattern.data());
+        const size_t    pattern_size = pattern.size() / sizeof(uint64_t);
+
+        for (uint64_t i = 0; i < count; ++i) {
+            if (pu[i] != pup[(i + idx) % pattern_size]) {
+                solid_throw("Message check failed.");
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+using MessagePointerT = solid::frame::mprpc::MessagePointerT<Message>;
+
+void client_connection_stop(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Info, _rctx.recipientId() << " error: " << _rctx.error().message());
+    if (!running) {
+        ++connection_count;
+    }
+}
+
+void client_connection_start(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Info, _rctx.recipientId());
+    auto lambda = [](frame::mprpc::ConnectionContext&, ErrorConditionT const& _rerror) {
+        solid_dbg(generic_logger, Info, "enter active error: " << _rerror.message());
+    };
+    _rctx.service().connectionNotifyEnterActiveState(_rctx.recipientId(), lambda);
+}
+
+void server_connection_stop(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Info, _rctx.recipientId() << " error: " << _rctx.error().message());
+}
+
+void server_connection_start(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Info, _rctx.recipientId());
+    auto lambda = [](frame::mprpc::ConnectionContext&, ErrorConditionT const& _rerror) {
+        solid_dbg(generic_logger, Info, "enter active error: " << _rerror.message());
+    };
+    _rctx.service().connectionNotifyEnterActiveState(_rctx.recipientId(), lambda);
+}
+
+void client_complete_message(
+    frame::mprpc::ConnectionContext& _rctx,
+    MessagePointerT& _rsent_msg_ptr, MessagePointerT& _rrecv_msg_ptr,
+    ErrorConditionT const& _rerror)
+{
+    solid_dbg(generic_logger, Info, _rctx.recipientId() << " " << crtbackidx << " " << crtwriteidx);
+
+    if (_rsent_msg_ptr) {
+        if (!_rerror) {
+            ++crtackidx;
+        }
+    }
+    if (_rrecv_msg_ptr) {
+        if (!_rrecv_msg_ptr->check()) {
+            solid_throw("Message check failed.");
+        }
+
+        // cout<< _rmsgptr->str.size()<<'\n';
+        transfered_size += _rrecv_msg_ptr->str.size();
+        ++transfered_count;
+
+        if (!_rrecv_msg_ptr->isBackOnSender()) {
+            solid_throw("Message not back on sender!.");
+        }
+
+        ++crtbackidx;
+
+        if (crtbackidx == crtwriteidx) {
+            lock_guard<mutex> lock(mtx);
+            running = false;
+            cnd.notify_one();
+        }
+    }
+}
+
+void server_complete_message(
+    frame::mprpc::ConnectionContext& _rctx,
+    MessagePointerT& _rsent_msg_ptr, MessagePointerT& _rrecv_msg_ptr,
+    ErrorConditionT const& /*_rerror*/)
+{
+    if (_rrecv_msg_ptr) {
+        solid_dbg(generic_logger, Info, _rctx.recipientId() << " received message with id on sender " << _rrecv_msg_ptr->senderRequestId() << " " << crtreadidx << " " << crtwriteidx);
+
+        if (!_rrecv_msg_ptr->check()) {
+            solid_throw("Message check failed.");
+        }
+
+        if (!_rrecv_msg_ptr->isOnPeer()) {
+            solid_throw("Message not on peer!.");
+        }
+
+        // send message back
+
+        solid_check(_rctx.recipientId().isValidConnection(), "Connection id should not be invalid!");
+
+        const auto err = _rctx.service().sendResponse(_rctx, _rrecv_msg_ptr);
+
+        solid_check(!err, "Connection id should not be invalid: " << err.message());
+
+        ++crtreadidx;
+
+        if (crtreadidx == 2) {
+            _rctx.pauseRead();
+            lock_guard<mutex> lock(mtx);
+            server_connection_paused = true;
+            server_connection_id     = _rctx.recipientId();
+            cnd.notify_one();
+        }
+    }
+    if (_rsent_msg_ptr) {
+        solid_dbg(generic_logger, Info, _rctx.recipientId() << " done sent message " << _rsent_msg_ptr.get());
+    }
+}
+
+} // namespace
+
+int test_clientserver_pause_read(int argc, char* argv[])
+{
+
+    solid::log_start(std::cerr, {".*:EWXS"});
+    // solid::log_start(std::cerr, {"solid::frame::mprpc.*:EWX", "\\*:VIEWX"});
+
+    size_t max_per_pool_connection_count = 1;
+
+    if (argc > 1) {
+        max_per_pool_connection_count = atoi(argv[1]);
+        if (max_per_pool_connection_count == 0) {
+            max_per_pool_connection_count = 1;
+        }
+        if (max_per_pool_connection_count > 100) {
+            max_per_pool_connection_count = 100;
+        }
+    }
+
+    bool secure   = false;
+    bool compress = false;
+
+    if (argc > 2) {
+        if (*argv[2] == 's' || *argv[2] == 'S') {
+            secure = true;
+        }
+        if (*argv[2] == 'c' || *argv[2] == 'C') {
+            compress = true;
+        }
+        if (*argv[2] == 'b' || *argv[2] == 'B') {
+            secure   = true;
+            compress = true;
+        }
+    }
+
+    if (argc > 3) {
+        if (*argv[3] == 'c' || *argv[3] == 'C') {
+            use_context_on_response = true;
+        }
+    }
+
+    for (int j = 0; j < 1; ++j) {
+        for (int i = 0; i < 127; ++i) {
+            int c = (i + j) % 127;
+            if (isprint(c) != 0 && isblank(c) == 0) {
+                pattern += static_cast<char>(c);
+            }
+        }
+    }
+
+    size_t sz = real_size(pattern.size());
+
+    if (sz > pattern.size()) {
+        pattern.resize(sz - sizeof(uint64_t));
+    } else if (sz < pattern.size()) {
+        pattern.resize(sz);
+    }
+
+    {
+        AioSchedulerT sch_client;
+        AioSchedulerT sch_server;
+
+        frame::Manager         m;
+        frame::mprpc::ServiceT mprpcserver(m);
+        frame::mprpc::ServiceT mprpcclient(m);
+        ErrorConditionT        err;
+        CallPoolT              cwp{{1, 100, 0}, [](const size_t) {}, [](const size_t) {}};
+        frame::aio::Resolver   resolver([&cwp](std::function<void()>&& _fnc) { cwp.pushOne(std::move(_fnc)); });
+
+        sch_client.start(1);
+        sch_server.start(1);
+
+        std::string server_port;
+
+        { // mprpc server initialization
+            auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
+                reflection::v1::metadata::factory,
+                [&](auto& _rmap) {
+                    _rmap.template registerMessage<Message>(1, "Message", server_complete_message);
+                });
+            frame::mprpc::Configuration cfg(sch_server, proto);
+
+            // cfg.recv_buffer_capacity = 1024;
+            // cfg.send_buffer_capacity = 1024;
+
+            cfg.connection_stop_fnc         = &server_connection_stop;
+            cfg.server.connection_start_fnc = &server_connection_start;
+
+            cfg.server.listener_address_str = "0.0.0.0:0";
+
+            if (secure) {
+                solid_dbg(generic_logger, Info, "Configure SSL server -------------------------------------");
+                frame::mprpc::openssl::setup_server(
+                    cfg,
+                    [](frame::aio::openssl::Context& _rctx) -> ErrorCodeT {
+                        _rctx.loadVerifyFile("echo-ca-cert.pem" /*"/etc/pki/tls/certs/ca-bundle.crt"*/);
+                        _rctx.loadCertificateFile("echo-server-cert.pem");
+                        _rctx.loadPrivateKeyFile("echo-server-key.pem");
+                        return ErrorCodeT();
+                    },
+                    frame::mprpc::openssl::NameCheckSecureStart{"echo-client"});
+            }
+
+            if (compress) {
+                frame::mprpc::snappy::setup(cfg);
+            }
+
+            {
+                frame::mprpc::ServiceStartStatus start_status;
+                mprpcserver.start(start_status, std::move(cfg));
+
+                std::ostringstream oss;
+                oss << start_status.listen_addr_vec_.back().port();
+                server_port = oss.str();
+                solid_dbg(generic_logger, Info, "server listens on: " << start_status.listen_addr_vec_.back());
+            }
+        }
+
+        { // mprpc client initialization
+            auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
+                reflection::v1::metadata::factory,
+                [&](auto& _rmap) {
+                    _rmap.template registerMessage<Message>(1, "Message", client_complete_message);
+                });
+            frame::mprpc::Configuration cfg(sch_client, proto);
+
+            // cfg.recv_buffer_capacity = 1024;
+            // cfg.send_buffer_capacity = 1024;
+
+            cfg.connection_stop_fnc         = &client_connection_stop;
+            cfg.client.connection_start_fnc = &client_connection_start;
+
+            cfg.pool_max_active_connection_count = 1; // NOTE: currently the test only works with one connection per pool
+
+            cfg.client.name_resolve_fnc = frame::mprpc::InternetResolverF{resolver, server_port};
+
+            if (secure) {
+                solid_dbg(generic_logger, Info, "Configure SSL client ------------------------------------");
+                frame::mprpc::openssl::setup_client(
+                    cfg,
+                    [](frame::aio::openssl::Context& _rctx) -> ErrorCodeT {
+                        _rctx.loadVerifyFile("echo-ca-cert.pem" /*"/etc/pki/tls/certs/ca-bundle.crt"*/);
+                        _rctx.loadCertificateFile("echo-client-cert.pem");
+                        _rctx.loadPrivateKeyFile("echo-client-key.pem");
+                        return ErrorCodeT();
+                    },
+                    frame::mprpc::openssl::NameCheckSecureStart{"echo-server"});
+            }
+
+            if (compress) {
+                frame::mprpc::snappy::setup(cfg);
+            }
+
+            mprpcclient.start(std::move(cfg));
+        }
+
+        pmprpcclient = &mprpcclient;
+
+        const size_t start_count = 10;
+
+        while (true) {
+            auto       msg_ptr = frame::mprpc::make_message<Message>(crtwriteidx);
+            const auto err     = mprpcclient.sendMessage(
+                {""}, msg_ptr,
+                initarray[crtwriteidx % initarraysize].flags | frame::mprpc::MessageFlagsE::AwaitResponse);
+            if (!err) {
+                ++crtwriteidx;
+                solid_check(crtwriteidx < 100000);
+            } else {
+                msg_ptr->serialized = true; // prevent crash
+                break;
+            }
+        }
+
+        cout << "Sent " << crtwriteidx << " messages" << endl;
+
+        this_thread::sleep_for(chrono::seconds(5));
+
+        cout << "Current read idx after sleep: " << crtreadidx << endl;
+
+        solid_check(crtwriteidx > crtreadidx);
+
+        unique_lock<mutex> lock(mtx);
+
+        // make sure server connection was paused
+        if (!cnd.wait_for(lock, std::chrono::seconds(10), []() { return server_connection_paused; })) {
+            solid_throw("Server connection still not paused.");
+        }
+
+        mprpcserver.connectionPost(server_connection_id, [](frame::mprpc::ConnectionContext& _rctx) {
+            _rctx.resumeRead();
+            cout << "Server connection " << _rctx.recipientId() << " resumed." << endl;
+        });
+
+        if (!cnd.wait_for(lock, std::chrono::seconds(220), []() { return !running; })) {
+            solid_throw("Process is taking too long.");
+        }
+
+        if (crtwriteidx != crtackidx) {
+            solid_throw("Not all messages were completed: crtwriteidx = " << crtwriteidx << " crtackidx = " << crtackidx);
+        }
+
+        mprpcclient.stop();
+        mprpcserver.stop();
+
+        solid_log(generic_logger, Statistic, "mprpcserver statistic: " << mprpcserver.statistic());
+        solid_log(generic_logger, Statistic, "mprpcclient statistic: " << mprpcclient.statistic());
+    }
+
+    // exiting
+
+    std::cout << "Transfered size = " << (transfered_size * 2) / 1024 << "KB" << endl;
+    std::cout << "Transfered count = " << transfered_count << endl;
+    std::cout << "Connection count = " << connection_count << endl;
+
+    return 0;
+}

--- a/solid/frame/mprpc/test/test_clientserver_split.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_split.cpp
@@ -228,6 +228,9 @@ void client_complete_message(
         const auto cnt = _rsent_msg_ptr->response_count;
 
         solid_dbg(generic_logger, Info, "response_cout = " << cnt << "/" << _rsent_msg_ptr->splitCount() << " is_rsp = " << is_response << " is_rsp_part = " << is_response_part << " is_rsp_last = " << is_response_last);
+        (void)is_response;
+        (void)is_response_part;
+        (void)is_response_last;
 
         transfered_size += _rrecv_msg_ptr->str.size();
         ++transfered_count;

--- a/solid/frame/mprpc/test/test_clientserver_stop.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_stop.cpp
@@ -1,0 +1,499 @@
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <thread>
+
+#include "solid/frame/mprpc/mprpcsocketstub_openssl.hpp"
+
+#include "solid/frame/mprpc/mprpccompression_snappy.hpp"
+#include "solid/frame/mprpc/mprpcconfiguration.hpp"
+#include "solid/frame/mprpc/mprpcprotocol_serialization_v3.hpp"
+#include "solid/frame/mprpc/mprpcservice.hpp"
+
+#include "solid/frame/manager.hpp"
+#include "solid/frame/scheduler.hpp"
+#include "solid/frame/service.hpp"
+
+#include "solid/frame/aio/aioactor.hpp"
+#include "solid/frame/aio/aiolistener.hpp"
+#include "solid/frame/aio/aioreactor.hpp"
+#include "solid/frame/aio/aioresolver.hpp"
+#include "solid/frame/aio/aiotimer.hpp"
+
+#include "solid/utility/threadpool.hpp"
+
+#include "solid/system/exception.hpp"
+
+#include "solid/system/log.hpp"
+#ifndef SOLID_ON_WINDOWS
+#include <signal.h>
+#endif
+
+using namespace std;
+using namespace solid;
+
+using AioSchedulerT  = frame::Scheduler<frame::aio::Reactor<frame::mprpc::EventT>>;
+using SecureContextT = frame::aio::openssl::Context;
+
+namespace {
+
+enum struct TestErrorE : int {
+    Dummy = 1
+};
+class TestErrorCategory : public ErrorCategoryT {
+public:
+    const char* name() const noexcept override
+    {
+        return "test";
+    }
+    std::string message(int _ev) const override;
+};
+
+const TestErrorCategory test_category;
+
+std::string TestErrorCategory::message(int _ev) const
+{
+    std::ostringstream oss;
+
+    oss << "(" << name() << ":" << _ev << "): ";
+
+    switch (_ev) {
+    case 0:
+        oss << "Success";
+        break;
+    case to_underlying(TestErrorE::Dummy):
+        oss << " Dummy";
+        break;
+    default:
+        oss << " Unknown [" << _ev << "]";
+        break;
+    };
+    return oss.str();
+}
+
+const ErrorConditionT error_test_dummy(to_underlying(TestErrorE::Dummy), test_category);
+
+struct InitStub {
+    size_t                      size;
+    frame::mprpc::MessageFlagsT flags;
+};
+
+using CallPoolT = ThreadPool<Function<void()>, Function<void()>>;
+
+InitStub initarray[] = {
+    {100000, 0},
+    {2000, 0},
+    {4000, 0},
+    {8000, 0},
+    {16000, 0},
+    {32000, 0},
+    {64000, 0},
+    {128000, 0},
+    {256000, 0},
+    {512000, 0},
+    {1024000, 0},
+    {2048000, 0},
+    {4096000, 0},
+    {8192000, 0},
+    {16384000, 0}};
+
+std::string  pattern;
+const size_t initarraysize = sizeof(initarray) / sizeof(InitStub);
+
+std::atomic<size_t> crtwriteidx(0);
+std::atomic<size_t> crtreadidx(0);
+std::atomic<size_t> crtbackidx(0);
+std::atomic<size_t> crtackidx(0);
+std::atomic<size_t> writecount(0);
+
+size_t                 connection_count(0);
+bool                   running = true;
+mutex                  mtx;
+condition_variable     cnd;
+frame::mprpc::Service* pmprpcclient = nullptr;
+std::atomic<uint64_t>  transfered_size(0);
+std::atomic<size_t>    transfered_count(0);
+bool                   use_context_on_response = false;
+
+size_t real_size(size_t _sz)
+{
+    // offset + (align - (offset mod align)) mod align
+    return _sz + ((sizeof(uint64_t) - (_sz % sizeof(uint64_t))) % sizeof(uint64_t));
+}
+
+struct Message : frame::mprpc::Message {
+    uint32_t     idx;
+    std::string  str;
+    mutable bool serialized;
+
+    Message(uint32_t _idx)
+        : idx(_idx)
+        , serialized(false)
+    {
+        solid_dbg(generic_logger, Info, "CREATE ---------------- " << this << " idx = " << idx);
+        init();
+    }
+    Message()
+        : serialized(false)
+    {
+        solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
+    }
+    ~Message() override
+    {
+        solid_dbg(generic_logger, Info, "DELETE ---------------- " << this);
+
+        // solid_assert(serialized || this->isBackOnSender());
+    }
+
+    SOLID_REFLECT_V1(_rr, _rthis, _rctx)
+    {
+        using ReflectorT = decay_t<decltype(_rr)>;
+
+        _rr.add(_rthis.idx, _rctx, 0, "idx").add(_rthis.str, _rctx, 1, "str");
+
+        if constexpr (ReflectorT::is_const_reflector) {
+            _rthis.serialized = true;
+        }
+    }
+
+    void init()
+    {
+        const size_t sz = real_size(initarray[idx % initarraysize].size);
+        str.resize(sz);
+        const size_t    count        = sz / sizeof(uint64_t);
+        uint64_t*       pu           = reinterpret_cast<uint64_t*>(const_cast<char*>(str.data()));
+        const uint64_t* pup          = reinterpret_cast<const uint64_t*>(pattern.data());
+        const size_t    pattern_size = pattern.size() / sizeof(uint64_t);
+        for (uint64_t i = 0; i < count; ++i) {
+            pu[i] = pup[(idx + i) % pattern_size]; // pattern[i % pattern.size()];
+        }
+    }
+
+    bool check() const
+    {
+        const size_t sz = real_size(initarray[idx % initarraysize].size);
+        solid_dbg(generic_logger, Info, "str.size = " << str.size() << " should be equal to " << sz);
+        if (sz != str.size()) {
+            return false;
+        }
+        // return true;
+        const size_t    count        = sz / sizeof(uint64_t);
+        const uint64_t* pu           = reinterpret_cast<const uint64_t*>(str.data());
+        const uint64_t* pup          = reinterpret_cast<const uint64_t*>(pattern.data());
+        const size_t    pattern_size = pattern.size() / sizeof(uint64_t);
+
+        for (uint64_t i = 0; i < count; ++i) {
+            if (pu[i] != pup[(i + idx) % pattern_size]) {
+                solid_throw("Message check failed.");
+                return false;
+            }
+        }
+        return true;
+    }
+};
+
+using MessagePointerT = solid::frame::mprpc::MessagePointerT<Message>;
+
+void client_connection_stop(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Info, _rctx.recipientId() << " error: " << _rctx.error().message());
+    if (!running) {
+        ++connection_count;
+    }
+}
+
+void client_connection_start(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Error, _rctx.recipientId());
+    auto lambda = [](frame::mprpc::ConnectionContext&, ErrorConditionT const& _rerror) {
+        solid_dbg(generic_logger, Error, "enter active error: " << _rerror.message());
+    };
+    _rctx.service().connectionNotifyEnterActiveState(_rctx.recipientId(), lambda);
+}
+
+void server_connection_stop(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Error, _rctx.recipientId() << " error: " << _rctx.error().message());
+    static bool b{true};
+    if (b) {
+        solid_check(_rctx.error() == error_test_dummy);
+        b = false;
+    }
+}
+
+void server_connection_start(frame::mprpc::ConnectionContext& _rctx)
+{
+    solid_dbg(generic_logger, Error, _rctx.recipientId());
+    auto lambda = [](frame::mprpc::ConnectionContext&, ErrorConditionT const& _rerror) {
+        solid_dbg(generic_logger, Error, "enter active error: " << _rerror.message());
+    };
+    _rctx.service().connectionNotifyEnterActiveState(_rctx.recipientId(), lambda);
+}
+
+void client_complete_message(
+    frame::mprpc::ConnectionContext& _rctx,
+    MessagePointerT& _rsent_msg_ptr, MessagePointerT& _rrecv_msg_ptr,
+    ErrorConditionT const& _rerror)
+{
+    solid_dbg(generic_logger, Info, _rctx.recipientId() << " " << crtbackidx << " " << writecount);
+
+    if (_rsent_msg_ptr) {
+        if (!_rerror) {
+            ++crtackidx;
+        }
+    }
+    if (_rrecv_msg_ptr) {
+        solid_check(_rrecv_msg_ptr->check(), "Message check failed.");
+
+        // cout<< _rmsgptr->str.size()<<'\n';
+        transfered_size += _rrecv_msg_ptr->str.size();
+        ++transfered_count;
+
+        solid_check(_rrecv_msg_ptr->isBackOnSender(), "Message not back on sender!.");
+
+        ++crtbackidx;
+
+        if (crtbackidx == writecount) {
+            solid_dbg(generic_logger, Error, _rctx.recipientId() << " " << crtbackidx << " " << writecount);
+            lock_guard<mutex> lock(mtx);
+            running = false;
+            cnd.notify_one();
+        }
+    }
+}
+
+void server_complete_message(
+    frame::mprpc::ConnectionContext& _rctx,
+    MessagePointerT& _rsent_msg_ptr, MessagePointerT& _rrecv_msg_ptr,
+    ErrorConditionT const& /*_rerror*/)
+{
+    if (_rrecv_msg_ptr) {
+        solid_dbg(generic_logger, Info, _rctx.recipientId() << " received message with id on sender " << _rrecv_msg_ptr->senderRequestId() << " " << crtreadidx << " " << writecount);
+
+        solid_check(_rrecv_msg_ptr->check(), "Message check failed.");
+        solid_check(_rrecv_msg_ptr->isOnPeer(), "Message not on peer!");
+        // send message back
+
+        solid_check(_rctx.recipientId().isValidConnection(), "Connection id should not be invalid!");
+
+        ErrorConditionT err = use_context_on_response ? _rctx.service().sendResponse(_rctx, _rrecv_msg_ptr) : _rctx.service().sendResponse(_rctx.recipientId(), _rrecv_msg_ptr);
+
+        // solid_check(!err, "Connection id should not be invalid: " << err.message());
+
+        ++crtreadidx;
+
+        if ((crtreadidx % 30) == 0) {
+            _rctx.stop(error_test_dummy);
+        }
+
+        solid_dbg(generic_logger, Info, crtreadidx << " " << crtwriteidx);
+        if (crtwriteidx < writecount) {
+            err = pmprpcclient->sendMessage(
+                {""}, frame::mprpc::make_message<Message>(crtwriteidx++),
+                initarray[crtwriteidx % initarraysize].flags | frame::mprpc::MessageFlagsE::AwaitResponse | frame::mprpc::MessageFlagsE::Idempotent);
+            solid_check(!err, "Connection id should not be invalid! " << err.message());
+        }
+    }
+    if (_rsent_msg_ptr) {
+        solid_dbg(generic_logger, Info, _rctx.recipientId() << " done sent message " << _rsent_msg_ptr.get());
+    }
+}
+
+} // namespace
+
+int test_clientserver_stop(int argc, char* argv[])
+{
+
+#ifndef SOLID_ON_WINDOWS
+    // signal(SIGINT, term_handler); /* Die on SIGTERM */
+    signal(SIGPIPE, SIG_IGN);
+#endif
+    solid::log_start(std::cerr, {".*:EWXS"});
+    // solid::log_start(std::cerr, {"solid::frame::mprpc::connection.*:EWX", ".*:EWXS", "\\*:EWX"});
+
+    size_t max_per_pool_connection_count = 1;
+
+    if (argc > 1) {
+        max_per_pool_connection_count = atoi(argv[1]);
+        if (max_per_pool_connection_count == 0) {
+            max_per_pool_connection_count = 1;
+        }
+        if (max_per_pool_connection_count > 100) {
+            max_per_pool_connection_count = 100;
+        }
+    }
+
+    bool secure   = false;
+    bool compress = false;
+
+    if (argc > 2) {
+        if (*argv[2] == 's' || *argv[2] == 'S') {
+            secure = true;
+        }
+        if (*argv[2] == 'c' || *argv[2] == 'C') {
+            compress = true;
+        }
+        if (*argv[2] == 'b' || *argv[2] == 'B') {
+            secure   = true;
+            compress = true;
+        }
+    }
+
+    if (argc > 3) {
+        if (*argv[3] == 'c' || *argv[3] == 'C') {
+            use_context_on_response = true;
+        }
+    }
+
+    for (int j = 0; j < 1; ++j) {
+        for (int i = 0; i < 127; ++i) {
+            int c = (i + j) % 127;
+            if (isprint(c) != 0 && isblank(c) == 0) {
+                pattern += static_cast<char>(c);
+            }
+        }
+    }
+
+    size_t sz = real_size(pattern.size());
+
+    if (sz > pattern.size()) {
+        pattern.resize(sz - sizeof(uint64_t));
+    } else if (sz < pattern.size()) {
+        pattern.resize(sz);
+    }
+
+    {
+        AioSchedulerT sch_client;
+        AioSchedulerT sch_server;
+
+        frame::Manager         m;
+        frame::mprpc::ServiceT mprpcserver(m);
+        frame::mprpc::ServiceT mprpcclient(m);
+        ErrorConditionT        err;
+        CallPoolT              cwp{{1, 100, 0}, [](const size_t) {}, [](const size_t) {}};
+        frame::aio::Resolver   resolver([&cwp](std::function<void()>&& _fnc) { cwp.pushOne(std::move(_fnc)); });
+
+        sch_client.start(1);
+        sch_server.start(1);
+
+        std::string server_port;
+
+        { // mprpc server initialization
+            auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
+                reflection::v1::metadata::factory,
+                [&](auto& _rmap) {
+                    _rmap.template registerMessage<Message>(1, "Message", server_complete_message);
+                });
+            frame::mprpc::Configuration cfg(sch_server, proto);
+
+            // cfg.recv_buffer_capacity = 1024;
+            // cfg.send_buffer_capacity = 1024;
+
+            cfg.connection_stop_fnc         = &server_connection_stop;
+            cfg.server.connection_start_fnc = &server_connection_start;
+
+            cfg.server.listener_address_str = "0.0.0.0:0";
+
+            if (secure) {
+                solid_dbg(generic_logger, Info, "Configure SSL server -------------------------------------");
+                frame::mprpc::openssl::setup_server(
+                    cfg,
+                    [](frame::aio::openssl::Context& _rctx) -> ErrorCodeT {
+                        _rctx.loadVerifyFile("echo-ca-cert.pem" /*"/etc/pki/tls/certs/ca-bundle.crt"*/);
+                        _rctx.loadCertificateFile("echo-server-cert.pem");
+                        _rctx.loadPrivateKeyFile("echo-server-key.pem");
+                        return ErrorCodeT();
+                    },
+                    frame::mprpc::openssl::NameCheckSecureStart{"echo-client"});
+            }
+
+            if (compress) {
+                frame::mprpc::snappy::setup(cfg);
+            }
+
+            {
+                frame::mprpc::ServiceStartStatus start_status;
+                mprpcserver.start(start_status, std::move(cfg));
+
+                std::ostringstream oss;
+                oss << start_status.listen_addr_vec_.back().port();
+                server_port = oss.str();
+                solid_dbg(generic_logger, Info, "server listens on: " << start_status.listen_addr_vec_.back());
+            }
+        }
+
+        { // mprpc client initialization
+            auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
+                reflection::v1::metadata::factory,
+                [&](auto& _rmap) {
+                    _rmap.template registerMessage<Message>(1, "Message", client_complete_message);
+                });
+            frame::mprpc::Configuration cfg(sch_client, proto);
+
+            // cfg.recv_buffer_capacity = 1024;
+            // cfg.send_buffer_capacity = 1024;
+
+            cfg.connection_stop_fnc         = &client_connection_stop;
+            cfg.client.connection_start_fnc = &client_connection_start;
+
+            cfg.pool_max_active_connection_count = max_per_pool_connection_count;
+
+            cfg.client.name_resolve_fnc = frame::mprpc::InternetResolverF{resolver, server_port};
+
+            if (secure) {
+                solid_dbg(generic_logger, Info, "Configure SSL client ------------------------------------");
+                frame::mprpc::openssl::setup_client(
+                    cfg,
+                    [](frame::aio::openssl::Context& _rctx) -> ErrorCodeT {
+                        _rctx.loadVerifyFile("echo-ca-cert.pem" /*"/etc/pki/tls/certs/ca-bundle.crt"*/);
+                        _rctx.loadCertificateFile("echo-client-cert.pem");
+                        _rctx.loadPrivateKeyFile("echo-client-key.pem");
+                        return ErrorCodeT();
+                    },
+                    frame::mprpc::openssl::NameCheckSecureStart{"echo-server"});
+            }
+
+            if (compress) {
+                frame::mprpc::snappy::setup(cfg);
+            }
+
+            mprpcclient.start(std::move(cfg));
+        }
+
+        pmprpcclient = &mprpcclient;
+
+        const size_t start_count = 10;
+
+        writecount = initarraysize * 10; // start_count;//
+
+        for (; crtwriteidx < start_count;) {
+            mprpcclient.sendMessage(
+                {""}, frame::mprpc::make_message<Message>(crtwriteidx++),
+                initarray[crtwriteidx % initarraysize].flags | frame::mprpc::MessageFlagsE::AwaitResponse | frame::mprpc::MessageFlagsE::Idempotent);
+        }
+
+        unique_lock<mutex> lock(mtx);
+
+        if (!cnd.wait_for(lock, std::chrono::seconds(220), []() { return !running; })) {
+            solid_throw("Process is taking too long.");
+        }
+
+        if (crtwriteidx != crtackidx) {
+            solid_throw("Not all messages were completed");
+        }
+
+        mprpcclient.stop();
+        mprpcserver.stop();
+
+        solid_log(generic_logger, Statistic, "mprpcserver statistic: " << mprpcserver.statistic());
+        solid_log(generic_logger, Statistic, "mprpcclient statistic: " << mprpcclient.statistic());
+    }
+
+    // exiting
+
+    std::cout << "Transfered size = " << (transfered_size * 2) / 1024 << "KB" << endl;
+    std::cout << "Transfered count = " << transfered_count << endl;
+    std::cout << "Connection count = " << connection_count << endl;
+
+    return 0;
+}

--- a/solid/frame/mprpc/test/test_clientserver_topic.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_topic.cpp
@@ -291,10 +291,10 @@ size_t                                          max_per_pool_connection_count = 
 std::atomic<size_t>                             client_connection_count{0};
 std::promise<void>                              client_connection_promise;
 std::promise<void>                              promise;
-std::atomic_bool                                running              = true;
-bool                                            cache_local_messages = false;
+std::atomic_bool                                running = true;
 thread_local unique_ptr<ThreadPoolLocalContext> local_thread_pool_context_ptr;
 chrono::microseconds                            test_duration{chrono::seconds(1)};
+// bool                                            cache_local_messages = false;
 
 #ifdef TRACE_DURATION
 DurationDqT duration_dq;

--- a/solid/frame/mprpc/test/test_clientserver_upload.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_upload.cpp
@@ -206,8 +206,9 @@ int test_clientserver_upload(int argc, char* argv[])
         increment_size = make_number(argv[3]);
     }
 
-    system("rm -rf client_storage");
-    system("rm -rf server_storage");
+    auto rv = system("rm -rf client_storage");
+    rv      = system("rm -rf server_storage");
+    (void)rv;
 
     Directory::create("client_storage");
     Directory::create("server_storage");

--- a/solid/frame/mprpc/test/test_clientserver_upload_single.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_upload_single.cpp
@@ -210,8 +210,9 @@ int test_clientserver_upload_single(int argc, char* argv[])
         increment_size = make_number(argv[3]);
     }
 
-    system("rm -rf client_storage");
-    system("rm -rf server_storage");
+    auto rv = system("rm -rf client_storage");
+    rv      = system("rm -rf server_storage");
+    (void)rv;
 
     Directory::create("client_storage");
     Directory::create("server_storage");

--- a/solid/frame/mprpc/test/test_clientserver_versioning.cpp
+++ b/solid/frame/mprpc/test/test_clientserver_versioning.cpp
@@ -133,9 +133,8 @@ void configure_service(frame::mprpc::ServiceT& _rsvc, AioSchedulerT& _rsch, fram
     auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
         reflection::v1::metadata::factory,
         [&](auto& _rmap) {
-            auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+            auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, const type_identity<T>& _rtype) {
+                _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
             };
             configure_protocol(lambda);
         });
@@ -204,9 +203,8 @@ void configure_service(frame::mprpc::ServiceT& _rsvc, AioSchedulerT& _rsch, fram
     auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
         reflection::v1::metadata::factory,
         [&](auto& _rmap) {
-            auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+            auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
             };
             configure_protocol(lambda);
         });
@@ -279,9 +277,8 @@ void configure_service(frame::mprpc::ServiceT& _rsvc, AioSchedulerT& _rsch, fram
     auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
         reflection::v1::metadata::factory,
         [&](auto& _rmap) {
-            auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+            auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
             };
             configure_protocol(lambda);
         });
@@ -353,9 +350,8 @@ void configure_service(frame::mprpc::ServiceT& _rsvc, AioSchedulerT& _rsch, fram
     auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
         reflection::v1::metadata::factory,
         [&](auto& _rmap) {
-            auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+            auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
             };
             configure_protocol(lambda);
         });
@@ -493,9 +489,8 @@ string configure_service(frame::mprpc::ServiceT& _rsvc, AioSchedulerT& _rsch)
     auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
         reflection::v1::metadata::factory,
         [&](auto& _rmap) {
-            auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                _rmap.template registerMessage<TypeT>(_id, _name, complete_message<TypeT>);
+            auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                _rmap.template registerMessage<T>(_id, _name, complete_message<T>);
             };
             configure_protocol(lambda);
         });

--- a/solid/frame/mprpc/test/test_clientserver_versioning_v1.hpp
+++ b/solid/frame/mprpc/test/test_clientserver_versioning_v1.hpp
@@ -108,10 +108,10 @@ struct Response : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "InitRequest", solid::TypeToType<InitRequest>());
-    _rreg(2, "InitResponse", solid::TypeToType<InitResponse>());
-    _rreg(4, "Request", solid::TypeToType<Request>());
-    _rreg(5, "Response", solid::TypeToType<Response>());
+    _rreg(1, "InitRequest", std::type_identity<InitRequest>{});
+    _rreg(2, "InitResponse", std::type_identity<InitResponse>{});
+    _rreg(4, "Request", std::type_identity<Request>{});
+    _rreg(5, "Response", std::type_identity<Response>{});
 }
 
 } // namespace v1

--- a/solid/frame/mprpc/test/test_clientserver_versioning_v2.hpp
+++ b/solid/frame/mprpc/test/test_clientserver_versioning_v2.hpp
@@ -116,10 +116,10 @@ struct Response : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "InitRequest", solid::TypeToType<InitRequest>());
-    _rreg(2, "InitResponse", solid::TypeToType<InitResponse>());
-    _rreg(4, "Request", solid::TypeToType<Request>());
-    _rreg(5, "Response", solid::TypeToType<Response>());
+    _rreg(1, "InitRequest", std::type_identity<InitRequest>());
+    _rreg(2, "InitResponse", std::type_identity<InitResponse>());
+    _rreg(4, "Request", std::type_identity<Request>());
+    _rreg(5, "Response", std::type_identity<Response>());
 }
 
 } // namespace v2

--- a/solid/frame/mprpc/test/test_clientserver_versioning_v3.hpp
+++ b/solid/frame/mprpc/test/test_clientserver_versioning_v3.hpp
@@ -139,11 +139,11 @@ struct Response2 : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "InitRequest", solid::TypeToType<InitRequest>());
-    _rreg(2, "InitResponse", solid::TypeToType<InitResponse>());
-    _rreg(4, "Request", solid::TypeToType<Request>());
-    _rreg(5, "Response", solid::TypeToType<Response>());
-    _rreg(6, "Response2", solid::TypeToType<Response2>());
+    _rreg(1, "InitRequest", std::type_identity<InitRequest>());
+    _rreg(2, "InitResponse", std::type_identity<InitResponse>());
+    _rreg(4, "Request", std::type_identity<Request>());
+    _rreg(5, "Response", std::type_identity<Response>());
+    _rreg(6, "Response2", std::type_identity<Response2>());
 }
 
 } // namespace v3

--- a/solid/frame/mprpc/test/test_clientserver_versioning_v4.hpp
+++ b/solid/frame/mprpc/test/test_clientserver_versioning_v4.hpp
@@ -120,12 +120,12 @@ struct Response2 : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "InitRequest", solid::TypeToType<InitRequest>());
-    _rreg(2, "InitResponse", solid::TypeToType<InitResponse>());
-    //_rreg(4, "Request", solid::TypeToType<Request>());
-    //_rreg(5, "Response", solid::TypeToType<Response>());
-    _rreg(6, "Response2", solid::TypeToType<Response2>());
-    _rreg(7, "Request2", solid::TypeToType<Request2>());
+    _rreg(1, "InitRequest", std::type_identity<InitRequest>());
+    _rreg(2, "InitResponse", std::type_identity<InitResponse>());
+    //_rreg(4, "Request", std::type_identity<Request>());
+    //_rreg(5, "Response", std::type_identity<Response>());
+    _rreg(6, "Response2", std::type_identity<Response2>());
+    _rreg(7, "Request2", std::type_identity<Request2>());
 }
 
 } // namespace v4

--- a/solid/frame/mprpc/test/test_protocol_basic.cpp
+++ b/solid/frame/mprpc/test/test_protocol_basic.cpp
@@ -173,11 +173,12 @@ void complete_message(
             msgbundle.message_ptr     = frame::mprpc::make_message<Message>(crtwriteidx);
             msgbundle.message_type_id = ctx.mprpcprotocol->typeIndex(msgbundle.message_ptr.get());
 
-            bool rv = ctx.mprpcmsgwriter->enqueue(
+            const bool rv = ctx.mprpcmsgwriter->enqueue(
                 *ctx.mprpcwriterconfig, msgbundle, pool_msg_id, writer_msg_id);
 
             solid_dbg(generic_logger, Info, "enqueue rv = " << rv << " writer_msg_id = " << writer_msg_id);
             solid_dbg(generic_logger, Info, frame::mprpc::MessageWriterPrintPairT(*ctx.mprpcmsgwriter, frame::mprpc::MessageWriter::PrintInnerListsE));
+            (void)rv;
             ++crtwriteidx;
         }
     }
@@ -318,10 +319,11 @@ int test_protocol_basic(int argc, char* argv[])
         msgbundle.message_ptr     = MessagePointerT(frame::mprpc::make_message<Message>(crtwriteidx));
         msgbundle.message_type_id = ctx.mprpcprotocol->typeIndex(msgbundle.message_ptr.get());
 
-        bool rv = mprpcmsgwriter.enqueue(
+        const bool rv = mprpcmsgwriter.enqueue(
             mprpcwriterconfig, msgbundle, pool_msg_id, writer_msg_id);
         solid_dbg(generic_logger, Info, "enqueue rv = " << rv << " writer_msg_id = " << writer_msg_id);
         solid_dbg(generic_logger, Info, frame::mprpc::MessageWriterPrintPairT(mprpcmsgwriter, frame::mprpc::MessageWriter::PrintInnerListsE));
+        (void)rv;
     }
 
     {

--- a/solid/frame/mprpc/test/test_protocol_common.hpp
+++ b/solid/frame/mprpc/test/test_protocol_common.hpp
@@ -15,9 +15,10 @@ class TestEntryway {
 public:
     static ConnectionContext& createContext()
     {
-        Connection&              rcon = *createConnection();
-        Service&                 rsvc = *createService();
-        static ConnectionContext conctx(rsvc, rcon);
+        Connection&                 rcon = *createConnection();
+        Service&                    rsvc = *createService();
+        frame::aio::ReactorContext& rctx = *createReactorContex();
+        static ConnectionContext    conctx(rctx, rsvc, rcon);
         return conctx;
     }
     static Connection* createConnection()
@@ -25,6 +26,10 @@ public:
         return nullptr;
     }
     static Service* createService()
+    {
+        return nullptr;
+    }
+    static frame::aio::ReactorContext* createReactorContex()
     {
         return nullptr;
     }

--- a/solid/frame/mprpc/test/test_protocol_synchronous.cpp
+++ b/solid/frame/mprpc/test/test_protocol_synchronous.cpp
@@ -160,11 +160,12 @@ void complete_message(
             msgbundle.message_ptr     = MessagePointerT(frame::mprpc::make_message<Message>(crtwriteidx));
             msgbundle.message_type_id = ctx.mprpcprotocol->typeIndex(msgbundle.message_ptr.get());
 
-            bool rv = ctx.mprpcmsgwriter->enqueue(
+            const bool rv = ctx.mprpcmsgwriter->enqueue(
                 *ctx.mprpcwriterconfig, msgbundle, pool_msg_id, writer_msg_id);
 
             solid_dbg(generic_logger, Info, "enqueue rv = " << rv << " writer_msg_id = " << writer_msg_id);
             solid_dbg(generic_logger, Info, frame::mprpc::MessageWriterPrintPairT(*ctx.mprpcmsgwriter, frame::mprpc::MessageWriter::PrintInnerListsE));
+            (void)rv;
             ++crtwriteidx;
         }
     }

--- a/solid/frame/mprpc/test/test_relay_basic.cpp
+++ b/solid/frame/mprpc/test/test_relay_basic.cpp
@@ -93,8 +93,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_cancel_request.cpp
+++ b/solid/frame/mprpc/test/test_relay_cancel_request.cpp
@@ -115,8 +115,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_cancel_response.cpp
+++ b/solid/frame/mprpc/test/test_relay_cancel_response.cpp
@@ -116,8 +116,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_close_request.cpp
+++ b/solid/frame/mprpc/test/test_relay_close_request.cpp
@@ -99,8 +99,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_close_response.cpp
+++ b/solid/frame/mprpc/test/test_relay_close_response.cpp
@@ -102,8 +102,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_detect_close.cpp
+++ b/solid/frame/mprpc/test/test_relay_detect_close.cpp
@@ -55,8 +55,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_detect_close_while_response.cpp
+++ b/solid/frame/mprpc/test/test_relay_detect_close_while_response.cpp
@@ -83,8 +83,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_disabled.cpp
+++ b/solid/frame/mprpc/test/test_relay_disabled.cpp
@@ -92,8 +92,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_split.cpp
+++ b/solid/frame/mprpc/test/test_relay_split.cpp
@@ -92,8 +92,8 @@ struct Register : frame::mprpc::Message {
     uint16_t replica_id_ = 0;
 
     Register(const uint32_t _group_id, uint32_t _err = 0)
-        : group_id_(_group_id)
-        , err_(_err)
+        : err_(_err)
+        , group_id_(_group_id)
     {
         solid_dbg(generic_logger, Info, "CREATE ---------------- " << this);
     }

--- a/solid/frame/mprpc/test/test_relay_split.cpp
+++ b/solid/frame/mprpc/test/test_relay_split.cpp
@@ -254,7 +254,7 @@ void peera_complete_message(
         (void)is_response;
         (void)is_response_part;
         (void)is_response_last;
-        
+
         transfered_size += _rrecv_msg_ptr->str.size();
         ++transfered_count;
 

--- a/solid/frame/mprpc/test/test_relay_split.cpp
+++ b/solid/frame/mprpc/test/test_relay_split.cpp
@@ -251,6 +251,10 @@ void peera_complete_message(
 
         solid_dbg(generic_logger, Info, _rctx.recipientId() << " received message with id on sender " << _rrecv_msg_ptr->senderRequestId() << " datasz = " << _rrecv_msg_ptr->str.size());
 
+        (void)is_response;
+        (void)is_response_part;
+        (void)is_response_last;
+        
         transfered_size += _rrecv_msg_ptr->str.size();
         ++transfered_count;
 

--- a/solid/frame/src/manager.cpp
+++ b/solid/frame/src/manager.cpp
@@ -840,8 +840,7 @@ ActorIdT Manager::id(const ActorBase& _ractor) const
         // std::lock_guard<std::mutex> actor_lock{pimpl_->actorMutex(actor_index)};
         const ActorStub& ras = rchunk[actor_index % pimpl_->actor_chunk_size_];
 
-        const ActorBase* pactor = ras.pactor_;
-        solid_assert_log(pactor == &_ractor, frame_logger);
+        solid_assert_log(ras.pactor_ == &_ractor, frame_logger);
         retval = ActorIdT(actor_index, ras.unique_);
     }
     return retval;

--- a/solid/reflection/v1/dispatch.hpp
+++ b/solid/reflection/v1/dispatch.hpp
@@ -26,6 +26,7 @@ enum struct TypeGroupE {
     Basic,
     Structure,
     Container,
+    VectorBool,
     Array,
     Bitset,
     Enum,
@@ -57,6 +58,8 @@ constexpr TypeGroupE type_group()
         return TypeGroupE::Enum;
     if constexpr (is_bitset_v<T>)
         return TypeGroupE::Bitset;
+    else if constexpr (is_std_vector_bool_v<T>)
+        return TypeGroupE::VectorBool;
     else if constexpr (solid::is_container_v<T>)
         return TypeGroupE::Container;
     else if constexpr (std::is_array<T>::value || solid::is_std_array_v<T>)

--- a/solid/reflection/v1/enummap.hpp
+++ b/solid/reflection/v1/enummap.hpp
@@ -33,7 +33,7 @@ public:
     using InitListT = std::initializer_list<std::pair<T, const char*>>;
 
     template <class T>
-    EnumMap(TypeToType<T> _t, InitListT<T> _init_list)
+    EnumMap(std::type_identity<T> _t, InitListT<T> _init_list)
     {
         static_assert(std::is_enum_v<T>, "T must be an enum");
 

--- a/solid/reflection/v1/metadata.hpp
+++ b/solid/reflection/v1/metadata.hpp
@@ -25,25 +25,6 @@ struct Generic {
 };
 
 struct Enum {
-    const EnumMap* pmap_ = nullptr;
-
-    Enum() {}
-
-    Enum(const EnumMap& _rmap)
-        : pmap_(&_rmap)
-    {
-    }
-
-    auto& map(const EnumMap& _rmap)
-    {
-        pmap_ = &_rmap;
-        return *this;
-    }
-
-    const EnumMap* map() const
-    {
-        return pmap_;
-    }
 };
 
 struct Pointer {

--- a/solid/reflection/v1/ostreamreflection.hpp
+++ b/solid/reflection/v1/ostreamreflection.hpp
@@ -65,7 +65,7 @@ struct OStreamVisitor {
         case tg::Enum: {
             auto& renum_node = *_rnode.template as<tg::Enum>();
             rostream_ << _name << '(' << _index << ") = ";
-            renum_node.print(rostream_, _rmeta.enumeration()->map());
+            renum_node.print(rostream_);
             rostream_ << eol_;
         } break;
         case tg::Structure:

--- a/solid/reflection/v1/ostreamreflection.hpp
+++ b/solid/reflection/v1/ostreamreflection.hpp
@@ -84,6 +84,14 @@ struct OStreamVisitor {
             indent();
             rostream_ << "]" << eol_;
             break;
+        case tg::VectorBool:
+            rostream_ << _name << '(' << _index << ") = [" << eol_;
+            ++indent_count_;
+            _rnode.template as<tg::VectorBool>()->for_each(std::ref(*this), _rctx);
+            --indent_count_;
+            indent();
+            rostream_ << "]" << eol_;
+            break;
         case tg::Array:
             rostream_ << _name << '(' << _index << ") = [" << eol_;
             ++indent_count_;

--- a/solid/reflection/v1/reflector.hpp
+++ b/solid/reflection/v1/reflector.hpp
@@ -123,6 +123,33 @@ public:
 };
 
 template <class Reflector>
+class GroupNode<Reflector, TypeGroupE::VectorBool> : public BaseNode<Reflector> {
+protected:
+    using ContextT = typename Reflector::ContextT;
+    using BaseT    = BaseNode<Reflector>;
+
+    GroupNode(Reflector& _rreflector, const std::type_info* const _ptype_info)
+        : BaseT(_rreflector, TypeGroupE::VectorBool, _ptype_info)
+    {
+    }
+
+public:
+    template <class DispatchFunction>
+    void for_each(DispatchFunction _dispatch_function, ContextT& _rctx)
+    {
+        Reflector new_reflector{this->rreflector_.metadataFactory(), _dispatch_function};
+        this->doForEach(new_reflector, _rctx);
+    }
+
+    template <class DispatchFunction>
+    void for_each(DispatchFunction _dispatch_function, ContextT& _rctx) const
+    {
+        Reflector new_reflector{this->rreflector_.metadataFactory(), _dispatch_function};
+        this->doForEach(new_reflector, _rctx);
+    }
+};
+
+template <class Reflector>
 class GroupNode<Reflector, TypeGroupE::Array> : public BaseNode<Reflector> {
 protected:
     using ContextT = typename Reflector::ContextT;
@@ -391,8 +418,15 @@ private:
             }
         } else if constexpr (type_group<ValueT>() == TypeGroupE::Container) {
             size_t i = 0;
-            for (typename ValueT::const_reference item : ref_) {
+            for (auto& item : ref_) {
                 _rreflector.add(item, _rctx, i, "");
+                ++i;
+            }
+        } else if constexpr (type_group<ValueT>() == TypeGroupE::VectorBool) {
+            size_t i = 0;
+            for (auto item : ref_) {
+                const bool b = item;
+                _rreflector.add(b, _rctx, i, "");
                 ++i;
             }
         } else if constexpr (type_group<ValueT>() == TypeGroupE::Structure) {
@@ -411,8 +445,15 @@ private:
             }
         } else if constexpr (type_group<ValueT>() == TypeGroupE::Container) {
             size_t i = 0;
-            for (typename ValueT::const_reference item : ref_) {
+            for (auto& item : ref_) {
                 _rreflector.add(item, _rctx, i, "");
+                ++i;
+            }
+        } else if constexpr (type_group<ValueT>() == TypeGroupE::VectorBool) {
+            size_t i = 0;
+            for (auto item : ref_) {
+                const bool b = item;
+                _rreflector.add(b, _rctx, i, "");
                 ++i;
             }
         } else if constexpr (type_group<ValueT>() == TypeGroupE::Structure) {
@@ -427,7 +468,7 @@ private:
         if constexpr (type_group<ValueT>() == TypeGroupE::SharedPtr || type_group<ValueT>() == TypeGroupE::UniquePtr || type_group<ValueT>() == TypeGroupE::IntrusivePtr) {
             solid_check(ref_);
             if constexpr (
-                type_group<typename T::element_type>() == TypeGroupE::Basic || type_group<typename T::element_type>() == TypeGroupE::Container || type_group<typename T::element_type>() == TypeGroupE::Enum || type_group<typename T::element_type>() == TypeGroupE::Bitset) {
+                type_group<typename T::element_type>() == TypeGroupE::Basic || type_group<typename T::element_type>() == TypeGroupE::Container || type_group<typename T::element_type>() == TypeGroupE::Enum || type_group<typename T::element_type>() == TypeGroupE::Bitset || type_group<typename T::element_type>() == TypeGroupE::VectorBool) {
                 _rreflector.add(*ref_, _rctx, 0, "");
             } else {
                 solid_check(_ptype_map != nullptr);
@@ -441,7 +482,7 @@ private:
         if constexpr (type_group<ValueT>() == TypeGroupE::SharedPtr || type_group<ValueT>() == TypeGroupE::UniquePtr || type_group<ValueT>() == TypeGroupE::IntrusivePtr) {
             solid_check(ref_);
             if constexpr (
-                type_group<typename T::element_type>() == TypeGroupE::Basic || type_group<typename T::element_type>() == TypeGroupE::Container || type_group<typename T::element_type>() == TypeGroupE::Enum || type_group<typename T::element_type>() == TypeGroupE::Bitset) {
+                type_group<typename T::element_type>() == TypeGroupE::Basic || type_group<typename T::element_type>() == TypeGroupE::Container || type_group<typename T::element_type>() == TypeGroupE::Enum || type_group<typename T::element_type>() == TypeGroupE::Bitset || type_group<typename T::element_type>() == TypeGroupE::VectorBool) {
                 _rreflector.add(*ref_, _rctx, 0, "");
             } else {
                 solid_check(_ptype_map != nullptr);

--- a/solid/reflection/v1/test/test_reflection_basic.cpp
+++ b/solid/reflection/v1/test/test_reflection_basic.cpp
@@ -35,9 +35,9 @@ enum UserStatus {
 };
 
 // const EnumMap figure_enum_map = {{Zero, "zero"}, {One, "one"}};
-const reflection::EnumMap figure_enum_map{TypeToType<FigureE>(), {{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
+const reflection::EnumMap figure_enum_map{std::type_identity<FigureE>(), {{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
 
-const reflection::EnumMap user_status_map = {TypeToType<UserStatus>(), {{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
+const reflection::EnumMap user_status_map = {std::type_identity<UserStatus>(), {{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
 
 struct Fruit {
     virtual ~Fruit() {}

--- a/solid/reflection/v1/test/test_reflection_basic.cpp
+++ b/solid/reflection/v1/test/test_reflection_basic.cpp
@@ -33,12 +33,12 @@ enum UserStatus {
     StatusSingleE,
     StatusRelationE,
 };
+} // namespace
 
-// const EnumMap figure_enum_map = {{Zero, "zero"}, {One, "one"}};
-const reflection::EnumMap figure_enum_map{std::type_identity<FigureE>(), {{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
+enummap_instance(FigureE){{{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
+enummap_instance(UserStatus){{{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
 
-const reflection::EnumMap user_status_map = {std::type_identity<UserStatus>(), {{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
-
+namespace {
 struct Fruit {
     virtual ~Fruit() {}
     virtual void print(ostream& _ros) = 0;
@@ -186,7 +186,7 @@ struct Test {
         {
             _rr.add([&_rthis](Reflector& _rr, Context& _rctx) {
                 _rr(_rctx, 1, _rthis.id_, "id", _rthis.name_, "name", _rthis.ip_vec_, "ip_vec");
-                _rr.add(_rthis.figure_, _rctx, 4, "figure", [](auto& _rmeta) { _rmeta.map(figure_enum_map); });
+                _rr.add(_rthis.figure_, _rctx, 4, "figure");
                 _rr.add(reflection::compacted{_rthis.comp_id_}, _rctx, 5, "comp_id");
             },
                 _rctx);
@@ -215,19 +215,19 @@ public:
         _rr.add(_rthis.user_vec_, _rctx, 1, "user_vec");
         _rr.add(_rthis.services_, _rctx, 2, "services");
         _rr.add(_rthis.vegetable_ptr_, _rctx, 4, "vegetable");
-        _rr.add(_rthis.fruit_ptr_, _rctx, 5, "fruit", [](auto& _rmeta) { _rmeta.map(*pfruits_map); });
+        _rr.add(_rthis.fruit_ptr_, _rctx, 5, "fruit");
         _rr.add(_rthis.guid_ptr_, _rctx, 6, "guid");
         _rr.add(_rthis.veg_tuple_, _rctx, 7, "veg_tuple");
         if constexpr (!ReflectorT::is_const_reflector) {
             auto progress_lambda = [](Context& _rctx, std::ostream& _ris, uint64_t _len, const bool _done, const size_t _index, const char* _name) {
                 // NOTE: here you can use context.any()for actual implementation
             };
-            _rr.add(_rthis.ofs_, _rctx, 8, "stream", [&progress_lambda](auto _rmeta) { _rmeta.progressFunction(progress_lambda); });
+            _rr.add(_rthis.ofs_, _rctx, 8, "stream", [&progress_lambda](auto& _rmeta) { _rmeta.progressFunction(progress_lambda); });
         } else {
             auto progress_lambda = [](Context& _rctx, std::istream& _ris, uint64_t _len, const bool _done, const size_t _index, const char* _name) {
                 // NOTE: here you can use context.any()for actual implementation
             };
-            _rr.add(_rthis.ifs_, _rctx, 8, "stream", [&progress_lambda](auto _rmeta) { _rmeta.progressFunction(progress_lambda); });
+            _rr.add(_rthis.ifs_, _rctx, 8, "stream", [&progress_lambda](auto& _rmeta) { _rmeta.progressFunction(progress_lambda); });
         }
     }
 };
@@ -273,7 +273,7 @@ struct OStreamVisitor {
         case tg::Enum: {
             auto& renum_node = *_rnode.template as<tg::Enum>();
             rostream_ << _name << '(' << _index << ") = ";
-            renum_node.print(rostream_, _rmeta.enumeration()->map());
+            renum_node.print(rostream_);
             rostream_ << endl;
         } break;
         case tg::Structure:

--- a/solid/reflection/v1/test/test_reflection_ostream.cpp
+++ b/solid/reflection/v1/test/test_reflection_ostream.cpp
@@ -34,12 +34,15 @@ enum UserStatus {
     StatusSingleE,
     StatusRelationE,
 };
+} // namespace
 
-// const EnumMap figure_enum_map = {{Zero, "zero"}, {One, "one"}};
-const reflection::EnumMap figure_enum_map{std::type_identity<FigureE>(), {{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
+// template <>
+// reflection::EnumMap<FigureE> solid::reflection::v1::enum_map_v<FigureE>
+enummap_instance(FigureE){{{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
 
-const reflection::EnumMap user_status_map = {std::type_identity<UserStatus>(), {{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
+enummap_instance(UserStatus){{{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
 
+namespace {
 struct Fruit {
     virtual ~Fruit() {}
     virtual void print(ostream& _ros) = 0;
@@ -188,7 +191,7 @@ struct Test {
                 _rr.add(_rthis.id_, _rctx, 1, "id");
                 _rr.add(_rthis.name_, _rctx, 2, "name");
                 _rr.add(_rthis.ip_vec_, _rctx, 3, "ip_vec");
-                _rr.add(_rthis.figure_, _rctx, 4, "figure", [](auto& _rmeta) { _rmeta.map(figure_enum_map); });
+                _rr.add(_rthis.figure_, _rctx, 4, "figure");
             },
                 _rctx);
         }
@@ -223,12 +226,12 @@ public:
             auto progress_lambda = [](Context& _rctx, std::ostream& _ris, uint64_t _len, const bool _done, const size_t _index, const char* _name) {
                 // NOTE: here you can use context.any()for actual implementation
             };
-            _rr.add(_rthis.ofs_, _rctx, 8, "stream", [&progress_lambda](auto _rmeta) { _rmeta.progressFunction(progress_lambda); });
+            _rr.add(_rthis.ofs_, _rctx, 8, "stream", [&progress_lambda](auto& _rmeta) { _rmeta.progressFunction(progress_lambda); });
         } else {
             auto progress_lambda = [](Context& _rctx, std::istream& _ris, uint64_t _len, const bool _done, const size_t _index, const char* _name) {
                 // NOTE: here you can use context.any()for actual implementation
             };
-            _rr.add(_rthis.ifs_, _rctx, 8, "stream", [&progress_lambda](auto _rmeta) { _rmeta.progressFunction(progress_lambda); });
+            _rr.add(_rthis.ifs_, _rctx, 8, "stream", [&progress_lambda](auto& _rmeta) { _rmeta.progressFunction(progress_lambda); });
         }
     }
 };

--- a/solid/reflection/v1/test/test_reflection_ostream.cpp
+++ b/solid/reflection/v1/test/test_reflection_ostream.cpp
@@ -36,9 +36,9 @@ enum UserStatus {
 };
 
 // const EnumMap figure_enum_map = {{Zero, "zero"}, {One, "one"}};
-const reflection::EnumMap figure_enum_map{TypeToType<FigureE>(), {{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
+const reflection::EnumMap figure_enum_map{std::type_identity<FigureE>(), {{Zero, "Zero"}, {One, "One"}, {Two, "Two"}, {Three, "Three"}, {Four, "Four"}, {Five, "Five"}, {Six, "Six"}, {Seven, "Seven"}, {Eight, "Eight"}, {Nine, "Nine"}}};
 
-const reflection::EnumMap user_status_map = {TypeToType<UserStatus>(), {{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
+const reflection::EnumMap user_status_map = {std::type_identity<UserStatus>(), {{StatusMarriedE, "Married"}, {StatusSingleE, "Single"}, {StatusRelationE, "Relation"}}};
 
 struct Fruit {
     virtual ~Fruit() {}

--- a/solid/serialization/v3/binarybasic.hpp
+++ b/solid/serialization/v3/binarybasic.hpp
@@ -22,7 +22,7 @@ namespace v3 {
 namespace binary {
 
 namespace impl {
-inline char* store(char* _pd, const uint8_t _val, TypeToType<uint8_t> _ff)
+inline char* store(char* _pd, const uint8_t _val, std::type_identity<uint8_t> _ff)
 {
     uint8_t* pd = reinterpret_cast<uint8_t*>(_pd);
     *pd         = _val;
@@ -34,7 +34,7 @@ union Convert16 {
     uint8_t  bytes_[sizeof(uint16_t)];
 };
 
-inline char* store(char* _pd, const uint16_t _val, TypeToType<uint16_t> _ff)
+inline char* store(char* _pd, const uint16_t _val, std::type_identity<uint16_t> _ff)
 {
     uint8_t*  pd = reinterpret_cast<uint8_t*>(_pd);
     Convert16 c;
@@ -54,7 +54,7 @@ union Convert32 {
     uint8_t  bytes_[sizeof(uint32_t)];
 };
 
-inline char* store(char* _pd, const uint32_t _val, TypeToType<uint32_t> _ff)
+inline char* store(char* _pd, const uint32_t _val, std::type_identity<uint32_t> _ff)
 {
     uint8_t*  pd = reinterpret_cast<uint8_t*>(_pd);
     Convert32 c;
@@ -78,7 +78,7 @@ union Convert64 {
     uint8_t  bytes_[sizeof(uint64_t)];
 };
 
-inline char* store(char* _pd, const uint64_t _val, TypeToType<uint64_t> _ff)
+inline char* store(char* _pd, const uint64_t _val, std::type_identity<uint64_t> _ff)
 {
     uint8_t*  pd = reinterpret_cast<uint8_t*>(_pd);
     Convert64 c;
@@ -121,7 +121,7 @@ union BytesConvertor {
 template <typename T>
 inline char* store(char* _pd, const T _v)
 {
-    return impl::store(_pd, _v, TypeToType<T>());
+    return impl::store(_pd, _v, std::type_identity<T>());
 }
 
 inline const char* load(const char* _ps, uint8_t& _val)

--- a/solid/serialization/v3/binarydeserializer.hpp
+++ b/solid/serialization/v3/binarydeserializer.hpp
@@ -185,7 +185,7 @@ public:
     }
 
     template <typename T, size_t Sz>
-    inline void addBinaryCArray(T (&_ra)[Sz], const uint64_t _limit, const char* _name)
+    inline void addCBinaryArray(T (&_ra)[Sz], const uint64_t _limit, const char* _name)
     {
         solid_log(logger, Info, _name);
         addBasicCompacted(data_.u64_, _name);
@@ -1150,7 +1150,7 @@ private:
             }
         } else if constexpr (std::is_array_v<T>) {
             static_assert(std::is_arithmetic_v<element_type_t<T>>, "C style arrays of other than arithmetic type, not supported");
-            addBinaryCArray(_rt, _meta.max_size_, _name);
+            addCBinaryArray(_rt, _meta.max_size_, _name);
         } else if constexpr (is_container_v<T>) {
             addContainer(*this, _rt, _meta.max_size_, _rctx, _name);
         } else {

--- a/solid/system/log.hpp
+++ b/solid/system/log.hpp
@@ -95,6 +95,7 @@ public:
     }
 };
 
+#ifdef SOLID_USE_STRINGSTREAM_VIEW
 class LogLineStringStream : public std::ostringstream, public LogLineBase {
 public:
     std::ostream& writeTo(std::ostream& _ros) const override
@@ -102,11 +103,13 @@ public:
         const auto view = this->view();
         return _ros.write(view.data(), view.size());
     }
+
     size_t size() const override
     {
-        return this->std::ostringstream::view().size();
+        this->std::ostringstream::view().size();
     }
 };
+#endif
 
 } // namespace impl
 

--- a/solid/system/test/test_exception.cpp
+++ b/solid/system/test/test_exception.cpp
@@ -83,6 +83,7 @@ int test_exception(int argc, char* argv[])
     }
 
     solid_assert_log(is_ok, solid::generic_logger);
+    (void)is_ok;
 
     return 0;
 }

--- a/solid/utility/cacheable.hpp
+++ b/solid/utility/cacheable.hpp
@@ -215,12 +215,12 @@ public:
     static auto load_sp()
     {
         auto& ls = local_stack_sp<What>();
-        if (ls.empty()) {
-            return std::shared_ptr<What>{};
-        } else {
+        if (!ls.empty()) {
             auto ret = std::move(ls.top());
             ls.pop();
             return ret;
+        } else {
+            return std::shared_ptr<What>{};
         }
     }
 
@@ -228,12 +228,12 @@ public:
     static auto load_ip()
     {
         auto& ls = local_stack_ip<What>();
-        if (ls.empty()) {
-            return IntrusivePtr<What>{};
-        } else {
-            auto ret(std::move(ls.top()));
+        if (!ls.empty()) {
+            auto ret = std::move(ls.top());
             ls.pop();
             return ret;
+        } else {
+            return IntrusivePtr<What>{};
         }
     }
 };

--- a/solid/utility/function.hpp
+++ b/solid/utility/function.hpp
@@ -165,7 +165,7 @@ RepresentationE do_copy(
         _rpbig_rtti = &big_rtti<T, R, ArgTypes...>;
         return RepresentationE::Big;
     } else {
-        solid_throw("Any: contained value not copyable");
+        solid_throw("Function: contained value not copyable");
         return RepresentationE::None;
     }
 }

--- a/solid/utility/src/utility.cpp
+++ b/solid/utility/src/utility.cpp
@@ -201,7 +201,7 @@ std::ostream& ThreadPoolStatistic::print(std::ostream& _ros) const
     _ros << " push_one_latency_max_us = " << push_one_latency_max_us_.load(std::memory_order_relaxed);
     _ros << " push_one_latency_min_us = " << push_one_latency_min_us_.load(std::memory_order_relaxed);
     const auto sum_ones = push_one_count_[0].load(std::memory_order_relaxed) + push_one_count_[1].load(std::memory_order_relaxed);
-    _ros << " push_one_latency_avg_us = " << sum_ones ? push_one_latency_sum_us_.load(std::memory_order_relaxed) / sum_ones : 0;
+    _ros << " push_one_latency_avg_us = " << (sum_ones ? push_one_latency_sum_us_.load(std::memory_order_relaxed) / sum_ones : 0);
     return _ros;
 }
 void ThreadPoolStatistic::clear() {}

--- a/solid/utility/test/test_threadpool_batch.cpp
+++ b/solid/utility/test/test_threadpool_batch.cpp
@@ -48,7 +48,7 @@ constexpr size_t thread_count = 10;
 
 #ifdef SOLID_ON_LINUX
 vector<int> isolcpus = {/*3, 4, 5, 6,*/ 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
-
+#if 0
 void set_current_thread_affinity()
 {
     if (std::thread::hardware_concurrency() < (thread_count + isolcpus[0])) {
@@ -64,6 +64,7 @@ void set_current_thread_affinity()
     // solid_check(rc == 0);
     (void)rc;
 }
+#endif
 #else
 void set_current_thread_affinity()
 {

--- a/solid/utility/test/test_threadpool_batch.cpp
+++ b/solid/utility/test/test_threadpool_batch.cpp
@@ -100,7 +100,7 @@ int test_threadpool_batch(int argc, char* argv[])
     solid::log_start(std::cerr, {".*:EWXS", "test:VIEWS"});
     int    wait_seconds = 500;
     size_t entry_count  = 300;
-    size_t repeat_count = 1000000;
+    // size_t repeat_count = 1000000;
     solid_log(logger, Verbose, "capacity " << capacity << " reminder " << (std::numeric_limits<atomic_size_t::value_type>::max() % capacity));
     {
         vector<AtomicCounterValueT> cnt_vec(capacity, 0);

--- a/solid/utility/threadpool.hpp
+++ b/solid/utility/threadpool.hpp
@@ -342,7 +342,7 @@ public:
 
     void push(Task&& _task, const uint64_t _all_id, const uint64_t _id)
     {
-        size_t index = -1;
+        size_t index = InvalidIndex{};
         if (!free_tasks_.empty()) {
             index = free_tasks_.backIndex();
             free_tasks_.popBack();
@@ -448,7 +448,7 @@ private:
 
     struct OneStub {
         AtomicCounterT     produce_count_{0};
-        AtomicCounterT     consume_count_{static_cast<AtomicCounterValueT>(-1)};
+        AtomicCounterT     consume_count_{std::numeric_limits<AtomicCounterValueT>::max()};
         std::uint8_t       event_              = {to_underlying(EventE::Fill)};
         TaskData<TaskOne>* data_ptr_           = nullptr;
         ContextStub*       pcontext_           = nullptr;
@@ -556,7 +556,7 @@ private:
 
     struct AllStub {
         AtomicCounterT       produce_count_{0};
-        AtomicCounterT       consume_count_{static_cast<AtomicCounterValueT>(-1)};
+        AtomicCounterT       consume_count_{std::numeric_limits<AtomicCounterValueT>::max()};
         std::atomic_uint32_t use_count_ = {0};
         std::atomic_uint64_t id_        = {0};
         TaskData<TaskAll>*   data_ptr_  = nullptr;

--- a/solid/utility/typetraits.hpp
+++ b/solid/utility/typetraits.hpp
@@ -164,6 +164,17 @@ template <class T>
 inline constexpr bool is_std_vector_v = is_std_vector<T>::value;
 
 template <typename T>
+struct is_std_vector_bool : std::false_type {
+};
+
+template <class A>
+struct is_std_vector_bool<std::vector<bool, A>> : std::true_type {
+};
+
+template <class T>
+inline constexpr bool is_std_vector_bool_v = is_std_vector_bool<T>::value;
+
+template <typename T>
 using element_type_t = std::remove_reference_t<decltype(*std::begin(std::declval<T&>()))>;
 
 } // namespace solid

--- a/tutorials/mprpc_echo/README.md
+++ b/tutorials/mprpc_echo/README.md
@@ -67,7 +67,7 @@ inline void protocol_setup(R _r, ProtocolT& _rproto)
 {
     _rproto.null(static_cast<ProtocolT::TypeIdT>(0));
 
-    _r(_rproto, solid::TypeToType<Message>(), 1);
+    _r(_rproto, std::type_identity<Message>(), 1);
 }
 
 }//namespace ipc_echo
@@ -96,7 +96,7 @@ inline void protocol_setup(Stub _s, ProtocolT& _rproto)
 {
     _rproto.null(static_cast<ProtocolT::TypeIdT>(0));
 
-    _s(_rproto, solid::TypeToType<Message>(), 1);
+    _s(_rproto, std::type_identity<Message>(), 1);
 }
 ```
 
@@ -194,7 +194,7 @@ void complete_message(
 }
 
 struct MessageSetup {
-    void operator()(ipc_echo::ProtocolT& _rprotocol, TypeToType<ipc_echo::Message> _t2t, const ipc_echo::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_echo::ProtocolT& _rprotocol, std::type_identity<ipc_echo::Message> _t2t, const ipc_echo::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<ipc_echo::Message>(complete_message<ipc_echo::Message>, _rtid);
     }
@@ -342,7 +342,7 @@ void complete_message(
 }
 
 struct MessageSetup {
-    void operator()(ipc_echo::ProtocolT& _rprotocol, TypeToType<ipc_echo::Message> _t2t, const ipc_echo::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_echo::ProtocolT& _rprotocol, std::type_identity<ipc_echo::Message> _t2t, const ipc_echo::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<ipc_echo::Message>(complete_message<ipc_echo::Message>, _rtid);
     }

--- a/tutorials/mprpc_echo/mprpc_echo_client.cpp
+++ b/tutorials/mprpc_echo/mprpc_echo_client.cpp
@@ -83,9 +83,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                        _rmap.template registerMessage<TypeT>(_id, _name, rpc_echo_client::complete_message<TypeT>);
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        _rmap.template registerMessage<T>(_id, _name, rpc_echo_client::complete_message<T>);
                     };
                     rpc_echo::configure_protocol(lambda);
                 });

--- a/tutorials/mprpc_echo/mprpc_echo_client_pool.cpp
+++ b/tutorials/mprpc_echo/mprpc_echo_client_pool.cpp
@@ -87,9 +87,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                        _rmap.template registerMessage<TypeT>(_id, _name, rpc_echo_client::complete_message<TypeT>);
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        _rmap.template registerMessage<T>(_id, _name, rpc_echo_client::complete_message<T>);
                     };
                     rpc_echo::configure_protocol(lambda);
                 });

--- a/tutorials/mprpc_echo/mprpc_echo_messages.hpp
+++ b/tutorials/mprpc_echo/mprpc_echo_messages.hpp
@@ -26,7 +26,7 @@ struct Message : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "Message", solid::TypeToType<Message>());
+    _rreg(1, "Message", std::type_identity<Message>());
 }
 
 } // namespace rpc_echo

--- a/tutorials/mprpc_echo/mprpc_echo_server.cpp
+++ b/tutorials/mprpc_echo/mprpc_echo_server.cpp
@@ -83,9 +83,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                        _rmap.template registerMessage<TypeT>(_id, _name, rpc_echo_server::complete_message<TypeT>);
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        _rmap.template registerMessage<T>(_id, _name, rpc_echo_server::complete_message<T>);
                     };
                     rpc_echo::configure_protocol(lambda);
                 });

--- a/tutorials/mprpc_file/README.md
+++ b/tutorials/mprpc_file/README.md
@@ -243,10 +243,10 @@ inline void protocol_setup(R _r, ProtocolT& _rproto)
 {
     _rproto.null(static_cast<ProtocolT::TypeIdT>(0));
 
-    _r(_rproto, solid::TypeToType<ListRequest>(), 1);
-    _r(_rproto, solid::TypeToType<ListResponse>(), 2);
-    _r(_rproto, solid::TypeToType<FileRequest>(), 3);
-    _r(_rproto, solid::TypeToType<FileResponse>(), 4);
+    _r(_rproto, std::type_identity<ListRequest>(), 1);
+    _r(_rproto, std::type_identity<ListResponse>(), 2);
+    _r(_rproto, std::type_identity<FileRequest>(), 3);
+    _r(_rproto, std::type_identity<FileResponse>(), 4);
 }
 
 ```
@@ -313,7 +313,7 @@ void complete_message(
 
 struct MessageSetup {
     template <class T>
-    void operator()(ipc_file::ProtocolT& _rprotocol, TypeToType<T> _t2t, const ipc_file::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_file::ProtocolT& _rprotocol, std::type_identity<T> _t2t, const ipc_file::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<T>(complete_message<T>, _rtid);
     }
@@ -585,7 +585,7 @@ void complete_message<ipc_file::FileResponse>(
 
 struct MessageSetup {
     template <class T>
-    void operator()(ipc_file::ProtocolT& _rprotocol, TypeToType<T> _t2t, const ipc_file::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_file::ProtocolT& _rprotocol, std::type_identity<T> _t2t, const ipc_file::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<T>(complete_message<T>, _rtid);
     }

--- a/tutorials/mprpc_file/mprpc_file_client.cpp
+++ b/tutorials/mprpc_file/mprpc_file_client.cpp
@@ -90,9 +90,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                        _rmap.template registerMessage<TypeT>(_id, _name, rpc_file_client::complete_message<TypeT>);
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        _rmap.template registerMessage<T>(_id, _name, rpc_file_client::complete_message<T>);
                     };
                     rpc_file::configure_protocol(lambda);
                 });

--- a/tutorials/mprpc_file/mprpc_file_messages.hpp
+++ b/tutorials/mprpc_file/mprpc_file_messages.hpp
@@ -135,10 +135,10 @@ private:
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "ListRequest", solid::TypeToType<ListRequest>());
-    _rreg(2, "ListResponse", solid::TypeToType<ListResponse>());
-    _rreg(3, "FileRequest", solid::TypeToType<FileRequest>());
-    _rreg(4, "FileResponse", solid::TypeToType<FileResponse>());
+    _rreg(1, "ListRequest", std::type_identity<ListRequest>());
+    _rreg(2, "ListResponse", std::type_identity<ListResponse>());
+    _rreg(3, "FileRequest", std::type_identity<FileRequest>());
+    _rreg(4, "FileResponse", std::type_identity<FileResponse>());
 }
 
 } // namespace rpc_file

--- a/tutorials/mprpc_file/mprpc_file_server.cpp
+++ b/tutorials/mprpc_file/mprpc_file_server.cpp
@@ -157,9 +157,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                        _rmap.template registerMessage<TypeT>(_id, _name, rpc_file_server::complete_message<TypeT>);
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        _rmap.template registerMessage<T>(_id, _name, rpc_file_server::complete_message<T>);
                     };
                     rpc_file::configure_protocol(lambda);
                 });

--- a/tutorials/mprpc_request/README.md
+++ b/tutorials/mprpc_request/README.md
@@ -128,8 +128,8 @@ inline void protocol_setup(R _r, ProtocolT& _rproto)
 {
     _rproto.null(ProtocolT::TypeIdT(0));
 
-    _r(_rproto, solid::TypeToType<Request>(), 1);
-    _r(_rproto, solid::TypeToType<Response>(), 2);
+    _r(_rproto, std::type_identity<Request>(), 1);
+    _r(_rproto, std::type_identity<Response>(), 2);
 }
 
 }//namespace ipc_request
@@ -206,7 +206,7 @@ void complete_message(
 
 struct MessageSetup {
     template <class T>
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<T>(complete_message<T>, _rtid);
     }
@@ -373,7 +373,7 @@ void complete_message<ipc_request::Response>(
 
 struct MessageSetup {
     template <class T>
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<T>(complete_message<T>, _rtid);
     }

--- a/tutorials/mprpc_request/mprpc_request_client.cpp
+++ b/tutorials/mprpc_request/mprpc_request_client.cpp
@@ -88,9 +88,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                        _rmap.template registerMessage<TypeT>(_id, _name, rpc_request_client::complete_message<TypeT>);
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        _rmap.template registerMessage<T>(_id, _name, rpc_request_client::complete_message<T>);
                     };
                     rpc_request::configure_protocol(lambda);
                 });

--- a/tutorials/mprpc_request/mprpc_request_messages.hpp
+++ b/tutorials/mprpc_request/mprpc_request_messages.hpp
@@ -71,8 +71,8 @@ struct Response : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "Request", solid::TypeToType<Request>());
-    _rreg(2, "Response", solid::TypeToType<Response>());
+    _rreg(1, "Request", std::type_identity<Request>());
+    _rreg(2, "Response", std::type_identity<Response>());
 }
 
 } // namespace rpc_request

--- a/tutorials/mprpc_request/mprpc_request_server.cpp
+++ b/tutorials/mprpc_request/mprpc_request_server.cpp
@@ -158,9 +158,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
-                        _rmap.template registerMessage<TypeT>(_id, _name, rpc_request_server::complete_message<TypeT>);
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        _rmap.template registerMessage<T>(_id, _name, rpc_request_server::complete_message<T>);
                     };
                     rpc_request::configure_protocol(lambda);
                 });

--- a/tutorials/mprpc_request_ssl/README.md
+++ b/tutorials/mprpc_request_ssl/README.md
@@ -291,15 +291,15 @@ inline void protocol_setup(R _r, ProtocolT& _rproto)
 {
     _rproto.null(ProtocolT::TypeIdT(0));
 
-    _r(_rproto, solid::TypeToType<Request>(), 1);
-    _r(_rproto, solid::TypeToType<Response>(), 2);
-    _r(_rproto, solid::TypeToType<RequestKeyAnd>(), 3);
-    _r(_rproto, solid::TypeToType<RequestKeyOr>(), 4);
-    _r(_rproto, solid::TypeToType<RequestKeyAndList>(), 5);
-    _r(_rproto, solid::TypeToType<RequestKeyOrList>(), 6);
-    _r(_rproto, solid::TypeToType<RequestKeyUserIdRegex>(), 7);
-    _r(_rproto, solid::TypeToType<RequestKeyEmailRegex>(), 8);
-    _r(_rproto, solid::TypeToType<RequestKeyYearLess>(), 9);
+    _r(_rproto, std::type_identity<Request>(), 1);
+    _r(_rproto, std::type_identity<Response>(), 2);
+    _r(_rproto, std::type_identity<RequestKeyAnd>(), 3);
+    _r(_rproto, std::type_identity<RequestKeyOr>(), 4);
+    _r(_rproto, std::type_identity<RequestKeyAndList>(), 5);
+    _r(_rproto, std::type_identity<RequestKeyOrList>(), 6);
+    _r(_rproto, std::type_identity<RequestKeyUserIdRegex>(), 7);
+    _r(_rproto, std::type_identity<RequestKeyEmailRegex>(), 8);
+    _r(_rproto, std::type_identity<RequestKeyYearLess>(), 9);
 }
 ```
 
@@ -324,43 +324,43 @@ void complete_message(
 
 struct MessageSetup {
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyAnd> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyAnd> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyAnd>(_rtid);
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyOr> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyOr> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyOr>(_rtid);
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyAndList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyAndList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyAndList>(_rtid);
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyOrList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyOrList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyOrList>(_rtid);
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyUserIdRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyUserIdRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyUserIdRegex>(_rtid);
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyEmailRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyEmailRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyEmailRegex>(_rtid);
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyYearLess> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyYearLess> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyYearLess>(_rtid);
     }
 
     template <class T>
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<T>(complete_message<T>, _rtid);
     }
@@ -457,50 +457,50 @@ but now, ipc_request_server::MessageSetup is a little more complex:
 ```C++
 struct MessageSetup {
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyAnd> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyAnd> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyAnd>(_rtid);
         _rprotocol.registerCast<RequestKeyAnd, RequestKey>();
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyOr> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyOr> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyOr>(_rtid);
         _rprotocol.registerCast<RequestKeyOr, RequestKey>();
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyAndList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyAndList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyAndList>(_rtid);
         _rprotocol.registerCast<RequestKeyAndList, RequestKey>();
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyOrList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyOrList> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyOrList>(_rtid);
         _rprotocol.registerCast<RequestKeyOrList, RequestKey>();
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyUserIdRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyUserIdRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyUserIdRegex>(_rtid);
         _rprotocol.registerCast<RequestKeyUserIdRegex, RequestKey>();
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyEmailRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyEmailRegex> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyEmailRegex>(_rtid);
         _rprotocol.registerCast<RequestKeyEmailRegex, RequestKey>();
     }
 
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<RequestKeyYearLess> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<RequestKeyYearLess> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerType<RequestKeyYearLess>(_rtid);
         _rprotocol.registerCast<RequestKeyYearLess, RequestKey>();
     }
 
     template <class T>
-    void operator()(ipc_request::ProtocolT& _rprotocol, TypeToType<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
+    void operator()(ipc_request::ProtocolT& _rprotocol, std::type_identity<T> _t2t, const ipc_request::ProtocolT::TypeIdT& _rtid)
     {
         _rprotocol.registerMessage<T>(complete_message<T>, _rtid);
     }

--- a/tutorials/mprpc_request_ssl/mprpc_request_client.cpp
+++ b/tutorials/mprpc_request_ssl/mprpc_request_client.cpp
@@ -104,8 +104,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        using TypeT = T;
 
                         if constexpr (std::is_base_of_v<rpc_request::RequestKey, TypeT>) {
                             _rmap.template registerType<TypeT, rpc_request::RequestKey>(_id, _name);

--- a/tutorials/mprpc_request_ssl/mprpc_request_messages.hpp
+++ b/tutorials/mprpc_request_ssl/mprpc_request_messages.hpp
@@ -316,15 +316,15 @@ struct Response : solid::frame::mprpc::Message {
 template <class Reg>
 inline void configure_protocol(Reg _rreg)
 {
-    _rreg(1, "Request", solid::TypeToType<Request>());
-    _rreg(2, "Response", solid::TypeToType<Response>());
-    _rreg(3, "RequestKeyAnd", solid::TypeToType<RequestKeyAnd>());
-    _rreg(4, "RequestKeyOr", solid::TypeToType<RequestKeyOr>());
-    _rreg(5, "RequestKeyAndList", solid::TypeToType<RequestKeyAndList>());
-    _rreg(6, "RequestKeyOrList", solid::TypeToType<RequestKeyOrList>());
-    _rreg(7, "RequestKeyUserIdRegex", solid::TypeToType<RequestKeyUserIdRegex>());
-    _rreg(8, "RequestKeyEmailRegex", solid::TypeToType<RequestKeyEmailRegex>());
-    _rreg(9, "RequestKeyYearLess", solid::TypeToType<RequestKeyYearLess>());
+    _rreg(1, "Request", std::type_identity<Request>());
+    _rreg(2, "Response", std::type_identity<Response>());
+    _rreg(3, "RequestKeyAnd", std::type_identity<RequestKeyAnd>());
+    _rreg(4, "RequestKeyOr", std::type_identity<RequestKeyOr>());
+    _rreg(5, "RequestKeyAndList", std::type_identity<RequestKeyAndList>());
+    _rreg(6, "RequestKeyOrList", std::type_identity<RequestKeyOrList>());
+    _rreg(7, "RequestKeyUserIdRegex", std::type_identity<RequestKeyUserIdRegex>());
+    _rreg(8, "RequestKeyEmailRegex", std::type_identity<RequestKeyEmailRegex>());
+    _rreg(9, "RequestKeyYearLess", std::type_identity<RequestKeyYearLess>());
 }
 
 } // namespace rpc_request

--- a/tutorials/mprpc_request_ssl/mprpc_request_server.cpp
+++ b/tutorials/mprpc_request_ssl/mprpc_request_server.cpp
@@ -326,8 +326,8 @@ int main(int argc, char* argv[])
             auto proto = frame::mprpc::serialization_v3::create_protocol<reflection::v1::metadata::Variant, uint8_t>(
                 reflection::v1::metadata::factory,
                 [&](auto& _rmap) {
-                    auto lambda = [&](const uint8_t _id, const std::string_view _name, auto const& _rtype) {
-                        using TypeT = typename std::decay_t<decltype(_rtype)>::TypeT;
+                    auto lambda = [&]<typename T>(const uint8_t _id, const std::string_view _name, type_identity<T> const& _rtype) {
+                        using TypeT = T;
 
                         if constexpr (std::is_base_of_v<rpc_request::RequestKey, TypeT>) {
                             _rmap.template registerType<TypeT, rpc_request::RequestKey>(_id, _name);


### PR DESCRIPTION
## Version 12.2
 * improvements and fixes on reflection
 * use std::variant in example_threadpool
 * TypeToType -> std::type_identity
 * mprpc: add support for ConnectionContext::pauseRead and Connection::Context::resumeRead
 * aio: stream fix not call doTrySend or doTryRecv after disconnect
 * mprpc: do not reset timer on onSend with error if connection already stopping
 * mprpc: add support for ConnectionContext::stop() for stopping the connection